### PR TITLE
Show active plans on landing page for AG

### DIFF
--- a/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
+++ b/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
@@ -1,7 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
 import { get } from "api/axios/axios";
 import { useApiBasePath } from "hooks/routeHooks";
 import { Oppfolgingsplan } from "../../../schema/oppfolgingsplanSchema";
-import { useQuery } from "@tanstack/react-query";
+import { erOppfolgingsplanAktiv } from "../../../utils/oppfolgingplanUtils";
 import { ApiErrorException } from "../../axios/errors";
 
 export const OPPFOLGINGSPLANER_AG = "oppfolgingsplaner-arbeidsgiver";
@@ -16,4 +17,15 @@ export const useOppfolgingsplanerAG = () => {
     [OPPFOLGINGSPLANER_AG],
     fetchOppfolgingsplaner
   );
+};
+
+export const useAktivePlanerAG = (): Oppfolgingsplan[] => {
+  const allePlaner = useOppfolgingsplanerAG();
+
+  if (allePlaner.isSuccess) {
+    return allePlaner.data.filter((oppfolgingsplan) => {
+      return erOppfolgingsplanAktiv(oppfolgingsplan);
+    });
+  }
+  return [];
 };

--- a/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
+++ b/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
@@ -19,13 +19,21 @@ export const useOppfolgingsplanerAG = () => {
   );
 };
 
-export const useAktivePlanerAG = (): Oppfolgingsplan[] => {
+export const useAktiveOppfolgingsplanerAG = () => {
   const allePlaner = useOppfolgingsplanerAG();
 
   if (allePlaner.isSuccess) {
-    return allePlaner.data.filter((oppfolgingsplan) => {
+    const planer = allePlaner.data.filter((oppfolgingsplan) => {
       return erOppfolgingsplanAktiv(oppfolgingsplan);
     });
+
+    return {
+      harAktiveOppfolgingsplaner: planer.length > 0,
+      aktiveOppfolgingsplaner: planer,
+    };
   }
-  return [];
+  return {
+    harAktiveOppfolgingsplaner: false,
+    aktiveOppfolgingsplaner: [],
+  };
 };

--- a/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
+++ b/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
@@ -23,9 +23,9 @@ export const useAktiveOppfolgingsplanerAG = () => {
   const allePlaner = useOppfolgingsplanerAG();
 
   if (allePlaner.isSuccess) {
-    const planer = allePlaner.data.filter((oppfolgingsplan) => {
-      return erOppfolgingsplanAktiv(oppfolgingsplan);
-    });
+    const planer = allePlaner.data.filter((oppfolgingsplan) =>
+      erOppfolgingsplanAktiv(oppfolgingsplan)
+    );
 
     return {
       harAktiveOppfolgingsplaner: planer.length > 0,

--- a/src/pages/arbeidsgiver/[narmestelederid].tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid].tsx
@@ -1,11 +1,15 @@
 import { NextPage } from "next";
 import React from "react";
+import { useAktivePlanerAG } from "../../api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG";
 import { beskyttetSideUtenProps } from "../../auth/beskyttetSide";
-import ArbeidsgiverSide from "../../components/blocks/wrappers/ArbeidsgiverSide";
 import OppfolgingsdialogerInfoPersonvern from "../../components/blocks/infoboks/OppfolgingsdialogerInfoPersonvern";
 import VideoPanel from "../../components/blocks/video/VideoPanel";
+import ArbeidsgiverSide from "../../components/blocks/wrappers/ArbeidsgiverSide";
+import OppfolgingsdialogTeasere from "../../components/landing/teaser/OppfolgingsdialogTeasere";
 
 const Home: NextPage = () => {
+  const aktiveOppfolgingsplaner = useAktivePlanerAG();
+
   return (
     <ArbeidsgiverSide
       title="Oppfølgingsplaner - Oversikt"
@@ -17,7 +21,12 @@ const Home: NextPage = () => {
         Alle godkjente planer kan ses i Altinn av de hos dere som har tilgang."
       />
 
-      <div>Arbeidsgiver TODO</div>
+      {aktiveOppfolgingsplaner.length > 0 && (
+        <OppfolgingsdialogTeasere
+          oppfolgingsplaner={aktiveOppfolgingsplaner}
+          tittel={"Aktiv oppfølgingsplan"}
+        />
+      )}
 
       <VideoPanel />
     </ArbeidsgiverSide>

--- a/src/pages/arbeidsgiver/[narmestelederid].tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid].tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import React from "react";
-import { useAktivePlanerAG } from "../../api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG";
+import { useAktiveOppfolgingsplanerAG } from "../../api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG";
 import { beskyttetSideUtenProps } from "../../auth/beskyttetSide";
 import OppfolgingsdialogerInfoPersonvern from "../../components/blocks/infoboks/OppfolgingsdialogerInfoPersonvern";
 import VideoPanel from "../../components/blocks/video/VideoPanel";
@@ -8,7 +8,8 @@ import ArbeidsgiverSide from "../../components/blocks/wrappers/ArbeidsgiverSide"
 import OppfolgingsdialogTeasere from "../../components/landing/teaser/OppfolgingsdialogTeasere";
 
 const Home: NextPage = () => {
-  const aktiveOppfolgingsplaner = useAktivePlanerAG();
+  const { harAktiveOppfolgingsplaner, aktiveOppfolgingsplaner } =
+    useAktiveOppfolgingsplanerAG();
 
   return (
     <ArbeidsgiverSide
@@ -21,7 +22,7 @@ const Home: NextPage = () => {
         Alle godkjente planer kan ses i Altinn av de hos dere som har tilgang."
       />
 
-      {aktiveOppfolgingsplaner.length > 0 && (
+      {harAktiveOppfolgingsplaner && (
         <OppfolgingsdialogTeasere
           oppfolgingsplaner={aktiveOppfolgingsplaner}
           tittel={"Aktiv oppfølgingsplan"}


### PR DESCRIPTION
Planen er å dele opp oppgaven med å lage landingsside for AG, slik at det kommer en PR for hver komponent som vises. Denne PR'en sørger for å vise aktive planer på landingssiden.