### PR TITLE
Filter plans on sykmeldt fnr

### DIFF
--- a/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
+++ b/src/api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG.ts
@@ -1,24 +1,35 @@
 import { useQuery } from "@tanstack/react-query";
 import { get } from "api/axios/axios";
 import { useApiBasePath } from "hooks/routeHooks";
-import { Oppfolgingsplan } from "../../../schema/oppfolgingsplanSchema";
+import { Oppfolgingsplan } from "schema/oppfolgingsplanSchema";
 import {
   erOppfolgingsplanAktiv,
   finnTidligereOppfolgingsplaner,
-} from "../../../utils/oppfolgingplanUtils";
-import { ApiErrorException } from "../../axios/errors";
+} from "utils/oppfolgingplanUtils";
+import { ApiErrorException } from "api/axios/errors";
+import { useDineSykmeldte } from "api/queries/arbeidsgiver/dinesykmeldteQueriesAG";
 
 export const OPPFOLGINGSPLANER_AG = "oppfolgingsplaner-arbeidsgiver";
 
 export const useOppfolgingsplanerAG = () => {
   const apiBasePath = useApiBasePath();
+  const sykmeldt = useDineSykmeldte();
+
+  const sykmeldtFnr = sykmeldt.data?.fnr;
 
   const fetchOppfolgingsplaner = () =>
-    get<Oppfolgingsplan[]>(`${apiBasePath}/oppfolgingsplaner`);
+    get<Oppfolgingsplan[]>(`${apiBasePath}/oppfolgingsplaner/`).then(
+      (oppfolgingsplaner) => {
+        return oppfolgingsplaner.filter(
+          (plan) => plan.arbeidstaker.fnr === sykmeldtFnr
+        );
+      }
+    );
 
   return useQuery<Oppfolgingsplan[], ApiErrorException>(
     [OPPFOLGINGSPLANER_AG],
-    fetchOppfolgingsplaner
+    fetchOppfolgingsplaner,
+    { enabled: !!sykmeldtFnr }
   );
 };
 

--- a/src/server/data/mock/defaultData/sykmeldinger-arbeidsgiver/defaultSykmeldtMockData.ts
+++ b/src/server/data/mock/defaultData/sykmeldinger-arbeidsgiver/defaultSykmeldtMockData.ts
@@ -1,9 +1,9 @@
-import { Sykmeldt } from "../../../../../schema/sykmeldtSchema";
+import { Sykmeldt } from "schema/sykmeldtSchema";
 
 export const defaultSykmeldtMockData: Sykmeldt = {
   narmestelederId: "123",
   orgnummer: "000111222",
-  fnr: "01010112345",
+  fnr: "110110110110",
   navn: "Kreativ Hatt",
   aktivSykmelding: true,
 };


### PR DESCRIPTION
Endepunktet i syfooppfolgingsplanservice som henter arbeidgivers oppfølgingsplaner henter alle planer de er involvert i, for alle arbeidstakere. For at bare planene til den sykmeldte man er inne og ser på, skal vises, må vi filtrere på fnr.

Ideelt sett bør dette sikkert håndteres i backend, jeg tenker at vi tar det når vi skal gjøre endringer i backend.