### PR TITLE
Swap nextlinks with designsystem for syncing issues between SM and AG

### DIFF
--- a/src/components/blocks/buttons/NavigationButtons.tsx
+++ b/src/components/blocks/buttons/NavigationButtons.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@navikt/ds-react";
+import { Button, Link } from "@navikt/ds-react";
 import React from "react";
 import { useLandingUrl, useOppfolgingsplanBasePath } from "hooks/routeHooks";
-import Link from "next/link";
 import { Row } from "../wrappers/Row";
 import { Page } from "../wrappers/OppfolgingsplanPageSM";
 

--- a/src/components/blocks/error/CantEditPlanError.tsx
+++ b/src/components/blocks/error/CantEditPlanError.tsx
@@ -1,5 +1,4 @@
-import { BodyLong, Button, GuidePanel } from "@navikt/ds-react";
-import Link from "next/link";
+import { BodyLong, Button, GuidePanel, Link } from "@navikt/ds-react";
 import { logger } from "@navikt/next-logger";
 import React from "react";
 import styled from "styled-components";
@@ -35,7 +34,6 @@ export const CantEditPlanError = ({ planStatus, aktivPlan }: Props) => {
   return (
     <SpacedGuidePanel>
       <BodyLong spacing>{errorText(planStatus)}</BodyLong>
-
       <Link href={`${landingUrl}/${aktivPlan?.id}`}>
         <Button
           variant={"primary"}

--- a/src/components/blocks/stepper/OppfolgingsplanStepper.tsx
+++ b/src/components/blocks/stepper/OppfolgingsplanStepper.tsx
@@ -2,7 +2,6 @@ import { Stepper } from "@navikt/ds-react";
 import React from "react";
 import { useOppfolgingsplanBasePath } from "hooks/routeHooks";
 import styled from "styled-components";
-import Link from "next/link";
 
 interface Props {
   activeStep: number;
@@ -18,17 +17,17 @@ export const OppfolgingsplanStepper = ({ activeStep }: Props) => {
 
   return (
     <StepperWithSpacing activeStep={activeStep} orientation="horizontal">
-      <Link href={`${basePath}/arbeidsoppgaver`} passHref={true} legacyBehavior>
-        <Stepper.Step unsafe_index={0}>Arbeidsoppgaver</Stepper.Step>
-      </Link>
+      <Stepper.Step href={`${basePath}/arbeidsoppgaver`} unsafe_index={0}>
+        Arbeidsoppgaver
+      </Stepper.Step>
 
-      <Link href={`${basePath}/tiltak`} passHref={true} legacyBehavior>
-        <Stepper.Step unsafe_index={1}>Tiltak</Stepper.Step>
-      </Link>
+      <Stepper.Step href={`${basePath}/tiltak`} unsafe_index={1}>
+        Tiltak
+      </Stepper.Step>
 
-      <Link href={`${basePath}/seplanen`} passHref={true} legacyBehavior>
-        <Stepper.Step unsafe_index={2}>Se planen</Stepper.Step>
-      </Link>
+      <Stepper.Step href={`${basePath}/seplanen`} unsafe_index={2}>
+        Se planen
+      </Stepper.Step>
     </StepperWithSpacing>
   );
 };

--- a/src/components/landing/opprett/ArbeidsgiverSkjema.tsx
+++ b/src/components/landing/opprett/ArbeidsgiverSkjema.tsx
@@ -4,8 +4,14 @@ import {
   erOppfolgingsplanOpprettbarMedArbeidsgiver,
   hentAktivOppfolgingsplanOpprettetMedArbeidsgiver,
 } from "utils/oppfolgingplanUtils";
-import { Alert, BodyShort, Button, Heading, Select } from "@navikt/ds-react";
-import Link from "next/link";
+import {
+  Alert,
+  BodyShort,
+  Button,
+  Heading,
+  Link,
+  Select,
+} from "@navikt/ds-react";
 import { ArbeidsgivereForGyldigeSykmeldinger } from "utils/sykmeldingUtils";
 import { useLandingUrl } from "hooks/routeHooks";
 import styled from "styled-components";

--- a/src/components/seplanen/OppfolgingsplanPanel.tsx
+++ b/src/components/seplanen/OppfolgingsplanPanel.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import Link from "next/link";
 import { LinkPanel, Panel } from "@navikt/ds-react";
 
 interface Props {
@@ -10,11 +9,9 @@ interface Props {
 export const OppfolgingsplanPanel = ({ children, href }: Props) => {
   if (href) {
     return (
-      <Link href={href}>
-        <LinkPanel as="div" border>
-          {children}
-        </LinkPanel>
-      </Link>
+      <LinkPanel href={href} border>
+        {children}
+      </LinkPanel>
     );
   }
 

--- a/src/components/seplanen/sendtilgodkjenning/SendTilGodkjenningToggle.tsx
+++ b/src/components/seplanen/sendtilgodkjenning/SendTilGodkjenningToggle.tsx
@@ -1,5 +1,4 @@
-import { Alert, BodyLong, Button, GuidePanel } from "@navikt/ds-react";
-import Link from "next/link";
+import { Alert, BodyLong, Button, GuidePanel, Link } from "@navikt/ds-react";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { useOppfolgingsplanUrl } from "hooks/routeHooks";

--- a/src/components/status/TilLandingssideKnapp.tsx
+++ b/src/components/status/TilLandingssideKnapp.tsx
@@ -1,16 +1,15 @@
 import { Back } from "@navikt/ds-icons";
-import { Button } from "@navikt/ds-react";
+import { Button, Link } from "@navikt/ds-react";
 import { useLandingUrl } from "hooks/routeHooks";
-import NextLink from "next/link";
 
 export const TilLandingssideKnapp = () => {
   const landingPage = useLandingUrl();
 
   return (
-    <NextLink href={landingPage}>
+    <Link href={landingPage}>
       <Button variant="tertiary" icon={<Back aria-hidden />}>
         Tilbake til oppfølgingsplaner
       </Button>
-    </NextLink>
+    </Link>
   );
 };

--- a/src/components/status/godkjentplanavbrutt/TilGjeldendePlanKnapp.tsx
+++ b/src/components/status/godkjentplanavbrutt/TilGjeldendePlanKnapp.tsx
@@ -1,7 +1,6 @@
 import { Back } from "@navikt/ds-icons";
-import { Button } from "@navikt/ds-react";
+import { Button, Link } from "@navikt/ds-react";
 import { useLandingUrl } from "hooks/routeHooks";
-import NextLink from "next/link";
 import { useGjeldendePlanSM } from "../../../api/queries/sykmeldt/oppfolgingsplanerQueriesSM";
 import { SpacedDiv } from "../../blocks/wrappers/SpacedDiv";
 import { Oppfolgingsplan } from "../../../types/oppfolgingsplan";
@@ -24,11 +23,11 @@ export const TilGjeldendePlanKnapp = ({ oppfolgingsplan }: Props) => {
 
   return (
     <SpacedDiv>
-      <NextLink href={url}>
+      <Link href={url}>
         <Button variant="tertiary" icon={<Back aria-hidden />}>
           Tilbake til den gjeldende utgave
         </Button>
-      </NextLink>
+      </Link>
     </SpacedDiv>
   );
 };

--- a/src/components/status/ingenplantilgodkjenning/IngenPlanTilGodkjenning.tsx
+++ b/src/components/status/ingenplantilgodkjenning/IngenPlanTilGodkjenning.tsx
@@ -1,5 +1,4 @@
-import { Alert, BodyLong } from "@navikt/ds-react";
-import Link from "next/link";
+import { Alert, BodyLong, Link } from "@navikt/ds-react";
 import React from "react";
 import { useLandingUrl } from "hooks/routeHooks";
 import { SpacedDiv } from "components/blocks/wrappers/SpacedDiv";

--- a/src/hooks/routeHooks.ts
+++ b/src/hooks/routeHooks.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
+import { basePath } from "../environments/publicEnv";
 
 export type Audience = "Sykmeldt" | "Arbeidsgiver";
 
@@ -30,9 +31,9 @@ export const useLandingUrl = (): string => {
   const { narmestelederid } = router.query;
 
   if (isAudienceSykmeldt) {
-    return "/sykmeldt";
+    return `${basePath}/sykmeldt`;
   } else {
-    return `/arbeidsgiver/${narmestelederid}`;
+    return `${basePath}/arbeidsgiver/${narmestelederid}`;
   }
 };
 


### PR DESCRIPTION
Designsystem-links kjører hard refresh (ny pageload) ved navigasjon. Håper er at dette vil få ned en god del av 409-problematikken vi ser. 

Foreslår vi tester dette en liten stund og ser om 409 går ned. Kan selvsagt også prøve å forbedre 409 på andre måter, men som en short-term fix

Ulempe er at full pagereload tar lengre tid enn router-navigasjon, men om det løser usync..