### PR TITLE
Send arbeidsgiver as parameter when sending to godkjenning

### DIFF
--- a/src/server/service/oppfolgingsplanService.ts
+++ b/src/server/service/oppfolgingsplanService.ts
@@ -318,7 +318,7 @@ export async function godkjennOppfolgingsplanAG(
       serverEnv.SYFOOPPFOLGINGSPLANSERVICE_HOST
     }/syfooppfolgingsplanservice/api/v2/oppfolgingsplan/actions/${oppfolgingsplanId}/godkjenn?status=${
       data.tvungenGodkjenning ? "tvungenGodkjenning" : "makrell"
-    }&aktoer=arbeidstaker&delmednav=${data.delmednav}`,
+    }&aktoer=arbeidsgiver&delmednav=${data.delmednav}`,
     data.gyldighetstidspunkt,
     { accessToken }
   );


### PR DESCRIPTION
Jeg oppdaget at vi sender `aktoer=arbeidstaker` når arbeidsgiver sender en plan til godkjenning. Det ser dog ikke ut som syfooppfolgingsplan bruker denne parameteren til noe, så jeg tror ikke det har ført til noen bugs