### PR TITLE
Add session scoped testscenario selector for labs

### DIFF
--- a/nais/naiserator-labs.yaml
+++ b/nais/naiserator-labs.yaml
@@ -59,4 +59,4 @@ spec:
     - name: MOCK_BACKEND
       value: "true"
     - name: DISPLAY_TESTSCENARIO_SELECTOR
-      value: "false"
+      value: "true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.36.1",
         "styled-components": "^5.3.5",
+        "uuid": "^9.0.0",
         "zod": "^3.19.1"
       },
       "devDependencies": {
@@ -41,6 +42,7 @@
         "@types/node": "18.7.17",
         "@types/react": "18.0.19",
         "@types/styled-components": "^5.1.26",
+        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "5.48.1",
         "@typescript-eslint/parser": "5.48.1",
         "eslint": "8.23.1",
@@ -2537,6 +2539,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -10536,6 +10544,14 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -12858,6 +12874,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
       "dev": true
     },
     "@types/yargs": {
@@ -18641,6 +18663,11 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.36.1",
     "styled-components": "^5.3.5",
+    "uuid": "^9.0.0",
     "zod": "^3.19.1"
   },
   "devDependencies": {
@@ -45,6 +46,7 @@
     "@types/node": "18.7.17",
     "@types/react": "18.0.19",
     "@types/styled-components": "^5.1.26",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "5.48.1",
     "@typescript-eslint/parser": "5.48.1",
     "eslint": "8.23.1",

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -7,6 +7,8 @@ import {
   networkError,
 } from "./errors";
 import { loginUser } from "utils/urlUtils";
+import { displayTestScenarioSelector } from "../../environments/publicEnv";
+import { v4 as uuidv4 } from "uuid";
 
 interface AxiosOptions {
   accessToken?: string;
@@ -18,6 +20,7 @@ interface AxiosOptions {
 export const AUTHORIZATION_HEADER = "Authorization";
 export const NAV_PERSONIDENT_HEADER = "nav-personident";
 export const ORGNUMMER_HEADER = "orgnummer";
+export const TEST_SESSION_ID = "testscenario-session-id";
 
 const defaultRequestHeaders = (
   options?: AxiosOptions
@@ -36,6 +39,15 @@ const defaultRequestHeaders = (
 
   if (options?.orgnummer) {
     headers[ORGNUMMER_HEADER] = options?.orgnummer;
+  }
+
+  if (displayTestScenarioSelector && typeof window !== "undefined") {
+    let sessionId = sessionStorage.getItem(TEST_SESSION_ID);
+    if (!sessionId) {
+      sessionId = uuidv4();
+      sessionStorage.setItem(TEST_SESSION_ID, sessionId);
+    }
+    headers[TEST_SESSION_ID] = sessionId;
   }
 
   return headers;

--- a/src/pages/api/arbeidsgiver/dinesykmeldte/[narmestelederId].ts
+++ b/src/pages/api/arbeidsgiver/dinesykmeldte/[narmestelederId].ts
@@ -10,7 +10,7 @@ const handler = async (
   res: NextApiResponse
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().sykmeldt);
+    res.status(200).json(getMockDb(req).sykmeldt);
   } else {
     const accessToken = await getDineSykmeldteTokenFromRequest(req);
     const { narmestelederId } = <{ narmestelederId: string }>req.query;

--- a/src/pages/api/arbeidsgiver/tilgang/[sykmeldtFnr].ts
+++ b/src/pages/api/arbeidsgiver/tilgang/[sykmeldtFnr].ts
@@ -5,13 +5,21 @@ import { getSyfoOppfolgingsplanserviceTokenFromRequest } from "../../../../serve
 import { getSykmeldtFnrFromRequest } from "../../../../server/utils/requestUtils";
 import { getTilgang } from "../../../../server/service/oppfolgingsplanService";
 import { beskyttetApi } from "../../../../server/auth/beskyttetApi";
+import { TEST_SESSION_ID } from "../../../../api/axios/axios";
+import { handleQueryParamError } from "../../../../server/utils/errors";
 
 const handler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().tilgang);
+    const sessionId = req.headers[TEST_SESSION_ID];
+
+    if (typeof sessionId !== "string") {
+      return handleQueryParamError(sessionId);
+    }
+
+    res.status(200).json(getMockDb(req).tilgang);
   } else {
     const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);
     const sykmeldtFnr = getSykmeldtFnrFromRequest(req);

--- a/src/pages/api/kontaktinfo/index.ts
+++ b/src/pages/api/kontaktinfo/index.ts
@@ -11,7 +11,7 @@ const handler = async (
   res: NextApiResponse
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().kontaktinfo);
+    res.status(200).json(getMockDb(req).kontaktinfo);
   } else {
     const syfoOppfolgingsplanServiceTokenX =
       await getSyfoOppfolgingsplanserviceTokenFromRequest(req);

--- a/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/[arbeidsoppgaveId]/slett.ts
+++ b/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/[arbeidsoppgaveId]/slett.ts
@@ -22,7 +22,7 @@ const handler = async (
   const arbeidsoppgaveId = getArbeidsoppgaveIdFromRequest(req);
 
   if (isMockBackend) {
-    const activeMock = getMockDb();
+    const activeMock = getMockDb(req);
 
     const aktivPlan = activeMock.oppfolgingsplaner.find(
       (plan) => plan.id === Number(oppfolgingsplanId)

--- a/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/tiltak/[tiltakId]/slett.ts
+++ b/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/tiltak/[tiltakId]/slett.ts
@@ -21,7 +21,7 @@ const handler = async (
   const tiltakId = getTiltakIdFromRequest(req);
 
   if (isMockBackend) {
-    const activeMock = getMockDb();
+    const activeMock = getMockDb(req);
 
     const aktivPlan = activeMock.oppfolgingsplaner.find(
       (plan) => plan.id === Number(oppfolgingsplanId)
@@ -34,12 +34,10 @@ const handler = async (
       );
     }
     const aktivPlanIndex = activeMock.oppfolgingsplaner.indexOf(aktivPlan);
-    const filteredTiltakListe = aktivPlan.tiltakListe!.filter(
-      (tiltak) => tiltak.tiltakId !== Number(tiltakId)
-    );
-
     activeMock.oppfolgingsplaner[aktivPlanIndex].tiltakListe =
-      filteredTiltakListe;
+      aktivPlan.tiltakListe?.filter(
+        (tiltak) => tiltak.tiltakId !== Number(tiltakId)
+      );
     res.status(200).end();
   } else {
     const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);

--- a/src/pages/api/scenario/activescenario.ts
+++ b/src/pages/api/scenario/activescenario.ts
@@ -5,6 +5,8 @@ import getMockDb, {
   TestScenario,
 } from "server/data/mock/getMockDb";
 import { getMockSetupForScenario } from "server/data/mock/activeMockData";
+import { TEST_SESSION_ID } from "../../../api/axios/axios";
+import { handleQueryParamError } from "../../../server/utils/errors";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!displayTestScenarioSelector) {
@@ -12,11 +14,17 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (req.method === "POST") {
+    const sessionId = req.headers[TEST_SESSION_ID];
+
+    if (typeof sessionId !== "string") {
+      return handleQueryParamError(sessionId);
+    }
+
     const newScenario: TestScenario = req.body;
-    assignNewDbSetup(getMockSetupForScenario(newScenario));
+    assignNewDbSetup(getMockSetupForScenario(newScenario), sessionId);
 
     res.status(200).end();
   } else {
-    res.status(200).json(getMockDb().activeTestScenario);
+    res.status(200).json(getMockDb(req).activeTestScenario);
   }
 }

--- a/src/pages/api/sykmeldt/narmesteledere/[sykmeldtFnr].ts
+++ b/src/pages/api/sykmeldt/narmesteledere/[sykmeldtFnr].ts
@@ -11,7 +11,7 @@ const handler = async (
   res: NextApiResponse
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().narmesteLedere);
+    res.status(200).json(getMockDb(req).narmesteLedere);
   } else {
     const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);
     const sykmeldtFnr = getSykmeldtFnrFromRequest(req);

--- a/src/pages/api/sykmeldt/oppfolgingsplaner/[oppfolgingsplanId]/oppgave/[arbeidsoppgaveId]/slett.ts
+++ b/src/pages/api/sykmeldt/oppfolgingsplaner/[oppfolgingsplanId]/oppgave/[arbeidsoppgaveId]/slett.ts
@@ -22,7 +22,7 @@ const handler = async (
   const arbeidsoppgaveId = getArbeidsoppgaveIdFromRequest(req);
 
   if (isMockBackend) {
-    const activeMock = getMockDb();
+    const activeMock = getMockDb(req);
 
     const aktivPlan = activeMock.oppfolgingsplaner.find(
       (plan) => plan.id === Number(oppfolgingsplanId)

--- a/src/pages/api/sykmeldt/sykmeldinger/index.ts
+++ b/src/pages/api/sykmeldt/sykmeldinger/index.ts
@@ -11,7 +11,7 @@ const handler = async (
   res: NextApiResponse<Sykmelding[]>
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().sykmeldinger);
+    res.status(200).json(getMockDb(req).sykmeldinger);
   } else {
     const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);
     const sykmeldingerResponse = await getSykmeldingerSM(tokenX);

--- a/src/pages/api/sykmeldt/tilgang/[sykmeldtFnr].ts
+++ b/src/pages/api/sykmeldt/tilgang/[sykmeldtFnr].ts
@@ -11,7 +11,7 @@ const handler = async (
   res: NextApiResponse
 ): Promise<void> => {
   if (isMockBackend) {
-    res.status(200).json(getMockDb().tilgang);
+    res.status(200).json(getMockDb(req).tilgang);
   } else {
     const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);
     const sykmeldtFnr = getSykmeldtFnrFromRequest(req);

--- a/src/server/data/arbeidsgiver/fetchOppfolgingsplanerMetaAG.ts
+++ b/src/server/data/arbeidsgiver/fetchOppfolgingsplanerMetaAG.ts
@@ -24,7 +24,7 @@ export const fetchOppfolgingsplanerMetaAG = async (
   const sykmeldtFnr = req.headers[NAV_PERSONIDENT_HEADER];
 
   if (isMockBackend) {
-    const activeMock = getMockDb();
+    const activeMock = getMockDb(req);
 
     return {
       person: activeMock.person,

--- a/src/server/data/mock/getMockDb.ts
+++ b/src/server/data/mock/getMockDb.ts
@@ -1,4 +1,4 @@
-import activeMockData from "./activeMockData";
+import activeMockData, { getMockSetupForScenario } from "./activeMockData";
 import {
   OppfolgingsplanDTO,
   VirksomhetDTO,
@@ -9,6 +9,9 @@ import { KontaktinfoDTO } from "../../../schema/kontaktinfoSchema";
 import { Tilgang } from "../../../schema/tilgangSchema";
 import { Sykmeldt } from "../../../schema/sykmeldtSchema";
 import { PersonV3DTO } from "../../../schema/personSchemas";
+import { TEST_SESSION_ID } from "../../../api/axios/axios";
+import { handleQueryParamError } from "../../utils/errors";
+import { NextApiRequest } from "next";
 
 export type TestScenario =
   | "INGENPLAN"
@@ -33,7 +36,7 @@ export interface MockSetup {
 
 declare global {
   // eslint-disable-next-line no-var
-  var _mockDb: MockSetup;
+  var _mockDb: { [key: string]: MockSetup };
 }
 
 /**
@@ -41,25 +44,28 @@ declare global {
  * that mutations were not persisted. Putting the MockDB on the global object
  * fixes this, but that only needs to be done when we are developing locally.
  */
-global._mockDb = global._mockDb || activeMockData;
+global._mockDb = global._mockDb || ["123", activeMockData];
 
-/**
- * Used ONLY by tests to reset the fake DB to initial values between tests
- */
-export function resetMockDb(): void {
-  if (process.env.NODE_ENV !== "test")
-    throw new Error("This is a test only utility");
-
-  global._mockDb = activeMockData;
+export function assignNewDbSetup(newSetup: MockSetup, sessionId: string): void {
+  global._mockDb[sessionId] = newSetup;
 }
 
-export function assignNewDbSetup(newSetup: MockSetup): void {
-  global._mockDb = newSetup;
-}
+const getMockDb = (req: NextApiRequest): MockSetup => {
+  const sessionId = req.headers[TEST_SESSION_ID];
 
-const getMockDb = (): MockSetup => {
+  if (typeof sessionId !== "string") {
+    return handleQueryParamError(sessionId);
+  }
+
   // global._mockDb = new FakeMockDB();
-  return global._mockDb;
+  let storedSetup = global._mockDb[sessionId];
+
+  if (!storedSetup) {
+    assignNewDbSetup(getMockSetupForScenario("UNDERARBEID"), sessionId);
+    storedSetup = global._mockDb[sessionId];
+  }
+
+  return storedSetup;
 };
 
 export default getMockDb;

--- a/src/server/data/sykmeldt/fetchOppfolgingsplanerMetaSM.ts
+++ b/src/server/data/sykmeldt/fetchOppfolgingsplanerMetaSM.ts
@@ -13,7 +13,7 @@ export const fetchOppfolgingsplanerMetaSM = async (
   req: NextApiRequest
 ): Promise<OppfolgingsplanMeta | undefined> => {
   if (isMockBackend) {
-    const activeMock = getMockDb();
+    const activeMock = getMockDb(req);
 
     return {
       person: activeMock.person,


### PR DESCRIPTION
Legger til en slags sesjonsid for mockdata knyttet til din nettlesersesjon, slik at vi trygt kan rulle ut testscenario-selector til labs. Da får hver enkelt veileder sin egen sesjon (egen instans av mockdata).

På sikt bør vi sikkert forbedre "UX-en", men det er kanskje greit enn så lenge.