### PR TITLE
Add mock service worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@hookform/devtools": "^4.3.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/node": "18.7.17",
         "@types/react": "18.0.19",
         "@types/styled-components": "^5.1.26",
@@ -51,11 +52,16 @@
         "eslint-config-next": "^13.1.1",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-testing-library": "^5.10.2",
         "husky": "^8.0.0",
         "jest": "^29.4.2",
         "jest-environment-jsdom": "^29.4.2",
         "lint-staged": "^13.1.0",
+        "msw": "^1.1.0",
+        "next-router-mock": "^0.9.2",
+        "open": "^8.4.2",
         "prettier": "^2.7.1",
+        "react-test-renderer": "^18.2.0",
         "typescript": "4.8.3"
       }
     },
@@ -979,6 +985,21 @@
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==",
       "dev": true
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -1687,6 +1708,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
+      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
+    },
     "node_modules/@navikt/dinesykmeldte-sidemeny": {
       "version": "3.0.0",
       "resolved": "https://npm.pkg.github.com/download/@navikt/dinesykmeldte-sidemeny/3.0.0/b50f76fceac6a9b90b17f0d0ae5a313501e2bb60",
@@ -2065,6 +2127,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "node_modules/@pkgr/utils": {
       "version": "2.3.1",
@@ -2512,6 +2580,19 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2565,6 +2646,21 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -2677,6 +2773,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -2727,6 +2829,12 @@
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2791,6 +2899,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -3059,6 +3176,128 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
+      "integrity": "sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
+      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.55.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.48.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
@@ -3222,6 +3461,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -3233,6 +3481,13 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "peer": true
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -3838,6 +4093,50 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -4038,6 +4337,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -4045,6 +4350,45 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -4101,6 +4445,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-table3": {
@@ -4161,6 +4517,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/client-only": {
@@ -4304,6 +4669,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/copy-anything": {
       "version": "2.0.6",
@@ -4875,6 +5249,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -5712,6 +6107,22 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.2.tgz",
+      "integrity": "sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.43.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -5946,6 +6357,44 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -6510,6 +6959,15 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6577,6 +7035,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -6833,6 +7297,77 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "node_modules/inquirer": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -6893,6 +7428,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -7007,6 +7554,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7035,6 +7597,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -7055,6 +7626,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -8875,6 +9452,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
@@ -9623,6 +10209,86 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.1.0.tgz",
+      "integrity": "sha512-oqMvUXm1bMbwvGpoXAQVz8vXXQyQyx52HBDg3EDOK+dFXkQHssgkXEG4LfMwwZyr2Qt18I/w04XPaY4BkFTkzA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.4.x <= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -9727,6 +10393,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-router-mock": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.2.tgz",
+      "integrity": "sha512-rh6Mq1xhZ4Y0y9Z3seHZ04k4dAKnAyRcis7q3ZUF+Xp0uBeNqPC8Ydw5DldYncN3o1sYBqRyz25F/v/kfcg0/Q==",
+      "dev": true,
+      "peerDependencies": {
+        "next": ">=10.0.0",
+        "react": ">=17.0.0"
       }
     },
     "node_modules/node-cache": {
@@ -9997,9 +10673,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -10047,10 +10723,64 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true
+    },
+    "node_modules/outvariant": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
+      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -10181,6 +10911,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -10739,6 +11475,19 @@
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-simple-animate": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/react-simple-animate/-/react-simple-animate-3.5.2.tgz",
@@ -10746,6 +11495,46 @@
       "dev": true,
       "peerDependencies": {
         "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/real-require": {
@@ -10955,6 +11744,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11099,6 +11897,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+      "dev": true
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -11293,6 +12097,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -12013,6 +12832,25 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -12095,6 +12933,27 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -13229,6 +14088,15 @@
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==",
       "dev": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -13778,6 +14646,43 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@mswjs/cookies": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
+      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "dev": true,
+      "requires": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "@mswjs/interceptors": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
+      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "dev": true,
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "@types/debug": "^4.1.7",
+        "@xmldom/xmldom": "^0.8.3",
+        "debug": "^4.3.3",
+        "headers-polyfill": "^3.1.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "dependencies": {
+        "strict-event-emitter": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
+          "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+          "dev": true,
+          "requires": {
+            "events": "^3.3.0"
+          }
+        }
+      }
+    },
     "@navikt/dinesykmeldte-sidemeny": {
       "version": "3.0.0",
       "resolved": "https://npm.pkg.github.com/download/@navikt/dinesykmeldte-sidemeny/3.0.0/b50f76fceac6a9b90b17f0d0ae5a313501e2bb60",
@@ -13990,6 +14895,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "@pkgr/utils": {
       "version": "2.3.1",
@@ -14321,6 +15232,13 @@
         "@types/react-dom": "^18.0.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -14371,6 +15289,21 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
       }
     },
     "@types/eslint": {
@@ -14476,6 +15409,12 @@
         }
       }
     },
+    "@types/js-levenshtein": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+      "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+      "dev": true
+    },
     "@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -14519,6 +15458,12 @@
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -14583,6 +15528,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "@types/set-cookie-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -14765,6 +15719,81 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/utils": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
+      "integrity": "sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.55.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
+          "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.55.0",
+            "@typescript-eslint/visitor-keys": "5.55.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.55.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+          "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.55.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+          "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.55.0",
+            "@typescript-eslint/visitor-keys": "5.55.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.55.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+          "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.55.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
+      }
+    },
     "@typescript-eslint/visitor-keys": {
       "version": "5.48.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
@@ -14921,6 +15950,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
+      "dev": true
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -14932,6 +15967,13 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "peer": true
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
     },
     "abab": {
       "version": "2.0.6",
@@ -15360,6 +16402,35 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -15496,11 +16567,44 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -15539,6 +16643,12 @@
       "requires": {
         "restore-cursor": "^3.1.0"
       }
+    },
+    "cli-spinners": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
+      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "dev": true
     },
     "cli-table3": {
       "version": "0.6.3",
@@ -15584,6 +16694,12 @@
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
       }
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
     },
     "client-only": {
       "version": "0.0.1",
@@ -15699,6 +16815,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "dev": true
     },
     "copy-anything": {
@@ -16126,6 +17248,23 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
       "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
       "dev": true
+    },
+    "defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "dev": true
+        }
+      }
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -16766,6 +17905,15 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-testing-library": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.2.tgz",
+      "integrity": "sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.43.0"
+      }
+    },
     "eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -16921,6 +18069,37 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
     },
     "extract-zip": {
       "version": "2.0.1",
@@ -17344,6 +18523,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -17387,6 +18572,12 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "headers-polyfill": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
+      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -17564,6 +18755,64 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "inquirer": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
+      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
+      }
+    },
     "internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -17609,6 +18858,15 @@
       "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-boolean-object": {
@@ -17678,6 +18936,15 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -17697,6 +18964,12 @@
         "is-path-inside": "^3.0.2"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -17707,6 +18980,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
+    "is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
       "dev": true
     },
     "is-number": {
@@ -19053,6 +20332,12 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.3.tgz",
       "integrity": "sha512-f8E/z+T3Q0kA9txzH2DKvH/ds2uggcw0m3vVPSB9HrSkrQ7mojjifvS7aR8cw+lQl2Fcmx9npwaHpM/M3GD8UQ=="
     },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-sdsl": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
@@ -19612,6 +20897,57 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msw": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.1.0.tgz",
+      "integrity": "sha512-oqMvUXm1bMbwvGpoXAQVz8vXXQyQyx52HBDg3EDOK+dFXkQHssgkXEG4LfMwwZyr2Qt18I/w04XPaY4BkFTkzA==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.2.2",
+        "@mswjs/interceptors": "^0.17.5",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/js-levenshtein": "^1.1.1",
+        "chalk": "4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.2",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "headers-polyfill": "^3.1.0",
+        "inquirer": "^8.2.0",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.7",
+        "outvariant": "^1.3.0",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.4.3",
+        "type-fest": "^2.19.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -19681,6 +21017,13 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.1.1"
       }
+    },
+    "next-router-mock": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.2.tgz",
+      "integrity": "sha512-rh6Mq1xhZ4Y0y9Z3seHZ04k4dAKnAyRcis7q3ZUF+Xp0uBeNqPC8Ydw5DldYncN3o1sYBqRyz25F/v/kfcg0/Q==",
+      "dev": true,
+      "requires": {}
     },
     "node-cache": {
       "version": "5.1.2",
@@ -19874,9 +21217,9 @@
       }
     },
     "open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",
@@ -19909,10 +21252,51 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true
+    },
+    "outvariant": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
+      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
       "dev": true
     },
     "p-limit": {
@@ -20001,6 +21385,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "path-type": {
@@ -20407,12 +21797,53 @@
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
     },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "react-simple-animate": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/react-simple-animate/-/react-simple-animate-3.5.2.tgz",
       "integrity": "sha512-xLE65euP920QMTOmv5haPlml+hmOPDkbIr5WeF7ADIXWBYt5kW/vwpNfWg8EKMab8aeDxIZ6QjffVh8v2dUyhg==",
       "dev": true,
       "requires": {}
+    },
+    "react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "requires": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "real-require": {
       "version": "0.2.0",
@@ -20564,6 +21995,12 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -20658,6 +22095,12 @@
       "requires": {
         "randombytes": "^2.1.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+      "dev": true
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -20806,6 +22249,21 @@
       "dev": true,
       "requires": {
         "internal-slot": "^1.0.4"
+      }
+    },
+    "strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-argv": {
@@ -21307,6 +22765,25 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -21375,6 +22852,25 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "prepare": "husky install",
     "test": "jest"
   },
+  "msw": {
+    "workerDirectory": "public"
+  },
   "dependencies": {
     "@navikt/dinesykmeldte-sidemeny": "^3.0.0",
     "@navikt/ds-css": "^2.0.1",
@@ -44,6 +47,7 @@
     "@hookform/devtools": "^4.3.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/node": "18.7.17",
     "@types/react": "18.0.19",
     "@types/styled-components": "^5.1.26",
@@ -55,11 +59,16 @@
     "eslint-config-next": "^13.1.1",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-testing-library": "^5.10.2",
     "husky": "^8.0.0",
     "jest": "^29.4.2",
     "jest-environment-jsdom": "^29.4.2",
     "lint-staged": "^13.1.0",
+    "msw": "^1.1.0",
+    "next-router-mock": "^0.9.2",
+    "open": "^8.4.2",
     "prettier": "^2.7.1",
+    "react-test-renderer": "^18.2.0",
     "typescript": "4.8.3"
   }
 }

--- a/src/api/queries/sykmeldt/narmesteLedereQueriesSM.ts
+++ b/src/api/queries/sykmeldt/narmesteLedereQueriesSM.ts
@@ -1,7 +1,7 @@
 import { useApiBasePath } from "../../../hooks/routeHooks";
 import { get } from "../../axios/axios";
 import { useSykmeldtFnr } from "./sykmeldingerQueriesSM";
-import { NarmesteLeder } from "../../../schema/narmestelederSchema";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
 import { useQuery } from "@tanstack/react-query";
 import { ApiErrorException } from "../../axios/errors";
 import { queryKeys } from "../queryKeys";
@@ -11,9 +11,9 @@ export const useNarmesteLedereSM = () => {
   const sykmeldtFnr = useSykmeldtFnr();
 
   const fetchNarmesteLedere = () =>
-    get<NarmesteLeder[]>(`${apiBasePath}/narmesteledere/${sykmeldtFnr}`);
+    get<NarmesteLederDTO[]>(`${apiBasePath}/narmesteledere/${sykmeldtFnr}`);
 
-  return useQuery<NarmesteLeder[], ApiErrorException>(
+  return useQuery<NarmesteLederDTO[], ApiErrorException>(
     [queryKeys.NARMESTELEDERE],
     fetchNarmesteLedere,
     {

--- a/src/api/queries/sykmeldt/sykmeldingerQueriesSM.ts
+++ b/src/api/queries/sykmeldt/sykmeldingerQueriesSM.ts
@@ -1,6 +1,6 @@
 import { useApiBasePath } from "../../../hooks/routeHooks";
 import { get } from "../../axios/axios";
-import { Sykmelding } from "../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../schema/sykmeldingSchema";
 import { useQuery } from "@tanstack/react-query";
 import { ApiErrorException } from "../../axios/errors";
 import { queryKeys } from "../queryKeys";
@@ -9,9 +9,9 @@ export const useSykmeldingerSM = () => {
   const apiBasePath = useApiBasePath();
 
   const fetchSykmeldinger = () =>
-    get<Sykmelding[]>(`${apiBasePath}/sykmeldinger`);
+    get<SykmeldingDTO[]>(`${apiBasePath}/sykmeldinger`);
 
-  return useQuery<Sykmelding[], ApiErrorException>(
+  return useQuery<SykmeldingDTO[], ApiErrorException>(
     [queryKeys.SYKMELDINGER],
     fetchSykmeldinger,
     {

--- a/src/components/landing/OppfolgingsplanContent.tsx
+++ b/src/components/landing/OppfolgingsplanContent.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { erSykmeldtUtenOppfolgingsplanerOgNaermesteLedere } from "../../utils/oppfolgingplanUtils";
-import { Sykmelding } from "../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../schema/sykmeldingSchema";
 import OppfolgingsdialogerVisning from "./teaser/OppfolgingsdialogerVisning";
 import { IngenLedereInfoBoks } from "../blocks/infoboks/IngenLedereInfoBoks";
 import { NarmesteLeder, Oppfolgingsplan } from "../../types/oppfolgingsplan";
 
 interface Props {
   oppfolgingsplaner: Oppfolgingsplan[];
-  sykmeldinger: Sykmelding[];
+  sykmeldinger: SykmeldingDTO[];
   narmesteLedere: NarmesteLeder[];
 }
 

--- a/src/components/landing/teaser/OppfolgingsdialogerVisning.tsx
+++ b/src/components/landing/teaser/OppfolgingsdialogerVisning.tsx
@@ -6,8 +6,8 @@ import {
 } from "../../../utils/oppfolgingplanUtils";
 import OppfolgingsdialogTeasere from "./OppfolgingsdialogTeasere";
 import { Button } from "@navikt/ds-react";
-import { NarmesteLeder } from "../../../schema/narmestelederSchema";
-import { Sykmelding } from "../../../schema/sykmeldingSchema";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
+import { SykmeldingDTO } from "../../../schema/sykmeldingSchema";
 import { finnArbeidsgivereForGyldigeSykmeldinger } from "../../../utils/sykmeldingUtils";
 import OpprettModalSM from "../../../components/landing/opprett/OpprettModalSM";
 import IngenPlanerCardSM from "../../../components/landing/opprett/IngenPlanerCardSM";
@@ -31,8 +31,8 @@ const texts = {
 
 interface Props {
   oppfolgingsplaner: Oppfolgingsplan[];
-  sykmeldinger: Sykmelding[];
-  narmesteLedere: NarmesteLeder[];
+  sykmeldinger: SykmeldingDTO[];
+  narmesteLedere: NarmesteLederDTO[];
 }
 
 const OppfolgingsdialogerVisning = ({

--- a/src/components/seplanen/ArbeidsgiverInfo.tsx
+++ b/src/components/seplanen/ArbeidsgiverInfo.tsx
@@ -1,12 +1,12 @@
 import { ContentWrapper } from "./ContentWrapper";
 import { Heading } from "@navikt/ds-react";
 import { texts } from "./texts";
-import { NarmesteLeder } from "../../schema/narmestelederSchema";
+import { NarmesteLederDTO } from "../../schema/narmestelederSchema";
 import { TextWithLabel } from "./TextWithLabel";
 import { Virksomhet } from "../../types/oppfolgingsplan";
 
 interface Props {
-  narmesteLeder?: NarmesteLeder | null;
+  narmesteLeder?: NarmesteLederDTO | null;
   virksomhet?: Virksomhet | null;
 }
 

--- a/src/components/status/godkjentplan/BothApprovedOppfolgingsplan.tsx
+++ b/src/components/status/godkjentplan/BothApprovedOppfolgingsplan.tsx
@@ -1,9 +1,9 @@
 import { BodyShort } from "@navikt/ds-react";
-import { NarmesteLeder } from "../../../schema/narmestelederSchema";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
 import { SpacedDiv } from "../../blocks/wrappers/SpacedDiv";
 
 interface Props {
-  narmesteLeder: NarmesteLeder;
+  narmesteLeder: NarmesteLederDTO;
 }
 
 export const BothApprovedOppfolgingsplan = ({ narmesteLeder }: Props) => {

--- a/src/mocks/data/constants.ts
+++ b/src/mocks/data/constants.ts
@@ -1,0 +1,19 @@
+export const NARMESTE_LEDER = {
+  navn: "Narmete Leder Navn",
+  fnr: "22345612345",
+};
+
+export const SYKMELDT = {
+  navn: "Sykmeldt Navn",
+  fnr: "12345612345",
+};
+
+export const VIRKSOMHET = {
+  navn: "Virksomhet Navn",
+  virksomhetsnummer: "123456789",
+};
+
+export const ORGANISASJONSINFORMASJON = {
+  orgnummer: "234567890",
+  orgNavn: "Organisasjons Navn",
+};

--- a/src/mocks/data/factories/oppfolgingsplan.ts
+++ b/src/mocks/data/factories/oppfolgingsplan.ts
@@ -1,0 +1,42 @@
+import {
+  Arbeidsoppgave,
+  Gjennomforing,
+  Person,
+} from "../../../types/oppfolgingsplan";
+
+export function createPerson(props?: Partial<Person>): Person {
+  return {
+    navn: "Person Navn",
+    fnr: "12345678901",
+    stillinger: [],
+    ...props,
+  };
+}
+
+export function createGjennomforing(
+  props?: Partial<Gjennomforing>
+): Gjennomforing {
+  return {
+    kanGjennomfoeres: "TILRETTELEGGING",
+    paaAnnetSted: false,
+    medMerTid: false,
+    medHjelp: false,
+    kanBeskrivelse: "Kan gjennomfores tekst",
+    kanIkkeBeskrivelse: null,
+    ...props,
+  };
+}
+export function createArbeidsoppgave(
+  props?: Partial<Arbeidsoppgave>
+): Arbeidsoppgave {
+  return {
+    arbeidsoppgaveId: 123,
+    arbeidsoppgavenavn: "Arbeidsoppgave navn",
+    erVurdertAvSykmeldt: false,
+    opprettetDato: "2020-11-08",
+    sistEndretDato: "2020-11-08",
+    sistEndretAv: createPerson(),
+    opprettetAv: createPerson(),
+    ...props,
+  };
+}

--- a/src/mocks/data/factories/oppfolgingsplanDTO.ts
+++ b/src/mocks/data/factories/oppfolgingsplanDTO.ts
@@ -1,0 +1,73 @@
+import {
+  ArbeidsgiverDTO,
+  OppfolgingsplanDTO,
+  PersonDTO,
+  VirksomhetDTO,
+} from "../../../schema/oppfolgingsplanSchema";
+import { NARMESTE_LEDER, VIRKSOMHET } from "../constants";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
+import { sykmeldtPersonDTO } from "../fixtures/personDTO";
+
+export function createVirksomhetDTO(
+  props?: Partial<VirksomhetDTO>
+): VirksomhetDTO {
+  return {
+    navn: VIRKSOMHET.navn,
+    virksomhetsnummer: VIRKSOMHET.virksomhetsnummer,
+    ...props,
+  };
+}
+
+export function createNarmesteLederDTO(
+  props?: Partial<NarmesteLederDTO>
+): NarmesteLederDTO {
+  return {
+    virksomhetsnummer: VIRKSOMHET.virksomhetsnummer,
+    aktivTom: null,
+    navn: NARMESTE_LEDER.navn,
+    epost: null,
+    tlf: null,
+    sistInnlogget: null,
+    samtykke: null,
+    ...props,
+  };
+}
+
+export function createArbeidsgiverDTO(
+  props?: Partial<ArbeidsgiverDTO>
+): ArbeidsgiverDTO {
+  return {
+    narmesteLeder: createNarmesteLederDTO(),
+    ...props,
+  };
+}
+
+export function createPersonDTO(props?: Partial<PersonDTO>): PersonDTO {
+  return {
+    navn: "Person Navn",
+    fnr: "12345678901",
+    stillinger: [],
+    ...props,
+  };
+}
+
+export const createOppfolgingsplanDTO = (
+  props?: Partial<OppfolgingsplanDTO>
+): OppfolgingsplanDTO => {
+  return {
+    id: 123,
+    sistEndretDato: "2020-11-08",
+    opprettetDato: "2020-11-08",
+    status: "UNDER_ARBEID",
+    virksomhet: createVirksomhetDTO(),
+    godkjentPlan: null,
+    godkjenninger: [],
+    arbeidsoppgaveListe: [],
+    tiltakListe: [],
+    avbruttPlanListe: [],
+    arbeidsgiver: createArbeidsgiverDTO(),
+    arbeidstaker: sykmeldtPersonDTO,
+    sistEndretAv: sykmeldtPersonDTO,
+    ...props,
+  };
+};

--- a/src/mocks/data/factories/sykmeldingDTO.ts
+++ b/src/mocks/data/factories/sykmeldingDTO.ts
@@ -1,0 +1,26 @@
+import {
+  OrganisasjonsinformasjonDTO,
+  SykmeldingDTO,
+} from "../../../schema/sykmeldingSchema";
+import { ORGANISASJONSINFORMASJON } from "../constants";
+
+export function createOrganisasjonsinformasjonDTO(
+  props?: Partial<OrganisasjonsinformasjonDTO>
+): OrganisasjonsinformasjonDTO {
+  return {
+    orgnummer: ORGANISASJONSINFORMASJON.orgnummer,
+    orgNavn: ORGANISASJONSINFORMASJON.orgNavn,
+    ...props,
+  };
+}
+export function createSykmeldingDTO(
+  props?: Partial<SykmeldingDTO>
+): SykmeldingDTO {
+  return {
+    id: "123",
+    fnr: "12345678902",
+    sykmeldingsperioder: [],
+    organisasjonsinformasjon: createOrganisasjonsinformasjonDTO(),
+    ...props,
+  };
+}

--- a/src/mocks/data/fixtures/arbeidsoppgave.ts
+++ b/src/mocks/data/fixtures/arbeidsoppgave.ts
@@ -1,0 +1,12 @@
+import {
+  createArbeidsoppgave,
+  createGjennomforing,
+} from "../factories/oppfolgingsplan";
+import { sykmeldtPerson } from "./person";
+
+export const gjennomfoeringWithTilrettelegging = createGjennomforing();
+export const arbeidsoppgaveCreatedBySM = createArbeidsoppgave({
+  sistEndretAv: sykmeldtPerson,
+  opprettetAv: sykmeldtPerson,
+  gjennomfoering: gjennomfoeringWithTilrettelegging,
+});

--- a/src/mocks/data/fixtures/person.ts
+++ b/src/mocks/data/fixtures/person.ts
@@ -1,0 +1,7 @@
+import { SYKMELDT } from "../constants";
+import { createPerson } from "../factories/oppfolgingsplan";
+
+export const sykmeldtPerson = createPerson({
+  navn: SYKMELDT.navn,
+  fnr: SYKMELDT.fnr,
+});

--- a/src/mocks/data/fixtures/personDTO.ts
+++ b/src/mocks/data/fixtures/personDTO.ts
@@ -1,0 +1,7 @@
+import { createPersonDTO } from "../factories/oppfolgingsplanDTO";
+import { SYKMELDT } from "../constants";
+
+export const sykmeldtPersonDTO = createPersonDTO({
+  navn: SYKMELDT.navn,
+  fnr: SYKMELDT.fnr,
+});

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,9 @@
+import { rest } from "msw";
+export const handlers = [
+  rest.post(
+    "/api/oppfolgingsplan/:planId/arbeidsoppgave/lagre",
+    (req, res, ctx) => {
+      return res(ctx.status(200));
+    }
+  ),
+];

--- a/src/mocks/testServer.ts
+++ b/src/mocks/testServer.ts
@@ -1,0 +1,4 @@
+import { handlers } from "./handlers";
+import { setupServer } from "msw/node";
+
+export const testServer = setupServer(...handlers);

--- a/src/mocks/worker.ts
+++ b/src/mocks/worker.ts
@@ -1,0 +1,4 @@
+import { handlers } from "./handlers";
+import { setupWorker } from "msw";
+
+export const worker = setupWorker(...handlers);

--- a/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/[arbeidsoppgaveId]/slett.ts
+++ b/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/[arbeidsoppgaveId]/slett.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { Sykmelding } from "../../../../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../../../../schema/sykmeldingSchema";
 import {
   getArbeidsoppgaveIdFromRequest,
   getOppfolgingsplanIdFromRequest,
@@ -16,7 +16,7 @@ import { isMockBackend } from "../../../../../../server/utils/serverEnv";
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<Sykmelding[]>
+  res: NextApiResponse<SykmeldingDTO[]>
 ): Promise<void> => {
   const oppfolgingsplanId = getOppfolgingsplanIdFromRequest(req);
   const arbeidsoppgaveId = getArbeidsoppgaveIdFromRequest(req);

--- a/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/lagre.ts
+++ b/src/pages/api/oppfolgingsplan/[oppfolgingsplanId]/arbeidsoppgave/lagre.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { Sykmelding } from "../../../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../../../schema/sykmeldingSchema";
 import { saveOppgave } from "../../../../../server/service/oppfolgingsplanService";
 import { beskyttetApi } from "../../../../../server/auth/beskyttetApi";
 import { getSyfoOppfolgingsplanserviceTokenFromRequest } from "../../../../../server/auth/tokenx/getTokenXFromRequest";
@@ -9,7 +9,7 @@ import { isMockBackend } from "../../../../../server/utils/serverEnv";
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<Sykmelding[]>
+  res: NextApiResponse<SykmeldingDTO[]>
 ): Promise<void> => {
   if (isMockBackend) {
     res.status(200).end();

--- a/src/pages/api/sykmeldt/oppfolgingsplaner/[oppfolgingsplanId]/oppgave/[arbeidsoppgaveId]/slett.ts
+++ b/src/pages/api/sykmeldt/oppfolgingsplaner/[oppfolgingsplanId]/oppgave/[arbeidsoppgaveId]/slett.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { Sykmelding } from "../../../../../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../../../../../schema/sykmeldingSchema";
 import { getSyfoOppfolgingsplanserviceTokenFromRequest } from "../../../../../../../server/auth/tokenx/getTokenXFromRequest";
 import {
   getArbeidsoppgaveIdFromRequest,
@@ -16,7 +16,7 @@ import { isMockBackend } from "../../../../../../../server/utils/serverEnv";
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<Sykmelding[]>
+  res: NextApiResponse<SykmeldingDTO[]>
 ): Promise<void> => {
   const oppfolgingsplanId = getOppfolgingsplanIdFromRequest(req);
   const arbeidsoppgaveId = getArbeidsoppgaveIdFromRequest(req);

--- a/src/pages/api/sykmeldt/sykmeldinger/index.ts
+++ b/src/pages/api/sykmeldt/sykmeldinger/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { Sykmelding } from "../../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../../schema/sykmeldingSchema";
 import getMockDb from "../../../../server/data/mock/getMockDb";
 import { getSykmeldingerSM } from "../../../../server/service/oppfolgingsplanService";
 import { beskyttetApi } from "../../../../server/auth/beskyttetApi";
@@ -8,7 +8,7 @@ import { isMockBackend } from "../../../../server/utils/serverEnv";
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<Sykmelding[]>
+  res: NextApiResponse<SykmeldingDTO[]>
 ): Promise<void> => {
   if (isMockBackend) {
     res.status(200).json(getMockDb(req).sykmeldinger);

--- a/src/schema/narmestelederSchema.ts
+++ b/src/schema/narmestelederSchema.ts
@@ -26,5 +26,5 @@ export const narmesteLederV3Schema = object({
   samtykke: boolean().nullable(),
 });
 
-export type NarmesteLeder = z.infer<typeof narmesteLederSchema>;
+export type NarmesteLederDTO = z.infer<typeof narmesteLederSchema>;
 export type NarmesteV3LederDTO = z.infer<typeof narmesteLederV3Schema>;

--- a/src/schema/oppfolgingsplanSchema.ts
+++ b/src/schema/oppfolgingsplanSchema.ts
@@ -139,3 +139,5 @@ export const oppfolgingsplanSchema = object({
 export type OppfolgingsplanDTO = z.infer<typeof oppfolgingsplanSchema>;
 export type StillingDTO = z.infer<typeof stillingSchema>;
 export type VirksomhetDTO = z.infer<typeof virksomhetSchema>;
+export type PersonDTO = z.infer<typeof personSchema>;
+export type ArbeidsgiverDTO = z.infer<typeof arbeidsgiverSchema>;

--- a/src/schema/sykmeldingSchema.ts
+++ b/src/schema/sykmeldingSchema.ts
@@ -18,7 +18,7 @@ export const sykmeldingSchema = object({
 });
 
 export type Sykmeldingsperiode = z.infer<typeof sykmeldingsperiodeSchema>;
-export type Sykmelding = z.infer<typeof sykmeldingSchema>;
-export type organisasjonsinformasjon = z.infer<
+export type SykmeldingDTO = z.infer<typeof sykmeldingSchema>;
+export type OrganisasjonsinformasjonDTO = z.infer<
   typeof organisasjonsinformasjonSchema
 >;

--- a/src/server/data/mapping/findName.ts
+++ b/src/server/data/mapping/findName.ts
@@ -1,8 +1,8 @@
-import { NarmesteLeder } from "../../../schema/narmestelederSchema";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
 import { PersonV3DTO } from "../../../schema/personSchemas";
 
 export const findName = (
-  narmesteLedere: NarmesteLeder[],
+  narmesteLedere: NarmesteLederDTO[],
   sykmeldt: PersonV3DTO,
   fnrToFind?: string | null
 ): string => {

--- a/src/server/data/mock/defaultData/oppfolgingsplanservice/defaultSykmeldingerMockData.ts
+++ b/src/server/data/mock/defaultData/oppfolgingsplanservice/defaultSykmeldingerMockData.ts
@@ -2,9 +2,9 @@ import {
   createDateMonthsAgo,
   createDateMonthsFromNow,
 } from "../../../../../utils/dateUtils";
-import { Sykmelding } from "../../../../../schema/sykmeldingSchema";
+import { SykmeldingDTO } from "../../../../../schema/sykmeldingSchema";
 
-export const defaultSykmeldingerMockData: Sykmelding[] = [
+export const defaultSykmeldingerMockData: SykmeldingDTO[] = [
   {
     id: "b341e1af-6a0d-4740-b8d9-eb3c5551fbc2",
     fnr: "12345678910",

--- a/src/server/data/mock/getMockDb.ts
+++ b/src/server/data/mock/getMockDb.ts
@@ -3,8 +3,8 @@ import {
   OppfolgingsplanDTO,
   VirksomhetDTO,
 } from "../../../schema/oppfolgingsplanSchema";
-import { Sykmelding } from "../../../schema/sykmeldingSchema";
-import { NarmesteLeder } from "../../../schema/narmestelederSchema";
+import { SykmeldingDTO } from "../../../schema/sykmeldingSchema";
+import { NarmesteLederDTO } from "../../../schema/narmestelederSchema";
 import { KontaktinfoDTO } from "../../../schema/kontaktinfoSchema";
 import { Tilgang } from "../../../schema/tilgangSchema";
 import { Sykmeldt } from "../../../schema/sykmeldtSchema";
@@ -24,9 +24,9 @@ export type TestScenario =
 
 export interface MockSetup {
   oppfolgingsplaner: OppfolgingsplanDTO[];
-  sykmeldinger: Sykmelding[];
+  sykmeldinger: SykmeldingDTO[];
   virksomhet: VirksomhetDTO[];
-  narmesteLedere: NarmesteLeder[];
+  narmesteLedere: NarmesteLederDTO[];
   person: PersonV3DTO;
   kontaktinfo: KontaktinfoDTO;
   tilgang: Tilgang;

--- a/src/server/types/OppfolgingsplanMeta.ts
+++ b/src/server/types/OppfolgingsplanMeta.ts
@@ -3,7 +3,7 @@ import {
   VirksomhetDTO,
 } from "../../schema/oppfolgingsplanSchema";
 import { KontaktinfoDTO } from "../../schema/kontaktinfoSchema";
-import { NarmesteLeder } from "../../schema/narmestelederSchema";
+import { NarmesteLederDTO } from "../../schema/narmestelederSchema";
 import { PersonV3DTO } from "../../schema/personSchemas";
 
 export interface OppfolgingsplanMeta {
@@ -11,5 +11,5 @@ export interface OppfolgingsplanMeta {
   oppfolgingsplaner: OppfolgingsplanDTO[];
   virksomhet: VirksomhetDTO[];
   kontaktinfo: KontaktinfoDTO;
-  narmesteLedere: NarmesteLeder[];
+  narmesteLedere: NarmesteLederDTO[];
 }

--- a/src/types/oppfolgingsplan.ts
+++ b/src/types/oppfolgingsplan.ts
@@ -119,7 +119,7 @@ export type NarmesteLeder = {
   sistInnlogget: string | null;
   samtykke: boolean | null;
 };
-type Arbeidsgiver = {
+export type Arbeidsgiver = {
   naermesteLeder?: NarmesteLeder;
 };
 

--- a/src/utils/oppfolgingplanUtils.ts
+++ b/src/utils/oppfolgingplanUtils.ts
@@ -7,8 +7,8 @@ import {
   finnArbeidsgivereForGyldigeSykmeldinger,
 } from "./sykmeldingUtils";
 import { erGyldigDatoIFortiden, getTime } from "./dateUtils";
-import { Sykmelding } from "../schema/sykmeldingSchema";
-import { NarmesteLeder } from "../schema/narmestelederSchema";
+import { SykmeldingDTO } from "../schema/sykmeldingSchema";
+import { NarmesteLederDTO } from "../schema/narmestelederSchema";
 import { Oppfolgingsplan } from "../types/oppfolgingsplan";
 
 export const inneholderGodkjenninger = (oppfolgingsplan: Oppfolgingsplan) => {
@@ -18,7 +18,7 @@ export const inneholderGodkjenninger = (oppfolgingsplan: Oppfolgingsplan) => {
 };
 
 export const erSykmeldingGyldigForOppfolgingMedGrensedato = (
-  sykmelding: Sykmelding,
+  sykmelding: SykmeldingDTO,
   dato: Date
 ) => {
   return (
@@ -42,7 +42,7 @@ export const erOppfolgingsplanKnyttetTilGyldigSykmeldingAG = (
 
 export const erOppfolgingsplanKnyttetTilGyldigSykmelding = (
   oppfolgingsplan: Oppfolgingsplan,
-  sykmeldinger: Sykmelding[]
+  sykmeldinger: SykmeldingDTO[]
 ) => {
   const dagensDato = new Date();
   return (
@@ -119,7 +119,7 @@ export const harTidligereOppfolgingsplanMedVirksomhet = (
 
 export const finnAktiveOppfolgingsplaner = (
   oppfolgingsplaner: Oppfolgingsplan[],
-  sykmeldinger?: Sykmelding[]
+  sykmeldinger?: SykmeldingDTO[]
 ) => {
   if (!sykmeldinger) {
     return oppfolgingsplaner.filter((plan) => {
@@ -172,8 +172,8 @@ export const erOppfolgingsplanOpprettbarMedArbeidsgiver = (
 
 export const erSykmeldtUtenOppfolgingsplanerOgNaermesteLedere = (
   oppfolgingsplaner: Oppfolgingsplan[],
-  sykmeldinger: Sykmelding[],
-  naermesteLedere: NarmesteLeder[]
+  sykmeldinger: SykmeldingDTO[],
+  naermesteLedere: NarmesteLederDTO[]
 ) => {
   return (
     oppfolgingsplaner.length === 0 &&

--- a/src/utils/sykmeldingUtils.ts
+++ b/src/utils/sykmeldingUtils.ts
@@ -1,10 +1,10 @@
 import { erSykmeldingGyldigForOppfolgingMedGrensedato } from "./oppfolgingplanUtils";
-import { Sykmelding } from "../schema/sykmeldingSchema";
-import { NarmesteLeder } from "../schema/narmestelederSchema";
+import { SykmeldingDTO } from "../schema/sykmeldingSchema";
+import { NarmesteLederDTO } from "../schema/narmestelederSchema";
 
 export const sykmeldtHarNaermestelederHosArbeidsgiver = (
   virksomhetsnummer: string,
-  naermesteLedere: NarmesteLeder[]
+  naermesteLedere: NarmesteLederDTO[]
 ) => {
   return (
     naermesteLedere.filter((leder) => {
@@ -15,7 +15,7 @@ export const sykmeldtHarNaermestelederHosArbeidsgiver = (
 
 export const finnSykmeldtSinNaermestelederNavnHosArbeidsgiver = (
   virksomhetsnummer: string,
-  naermesteLedere: NarmesteLeder[]
+  naermesteLedere: NarmesteLederDTO[]
 ) => {
   const naermesteLeder = naermesteLedere.filter((leder) => {
     return virksomhetsnummer === leder.virksomhetsnummer && leder.erAktiv;
@@ -24,12 +24,12 @@ export const finnSykmeldtSinNaermestelederNavnHosArbeidsgiver = (
 };
 
 export const sykmeldtHarIngenSendteSykmeldinger = (
-  sykmeldinger: Sykmelding[]
+  sykmeldinger: SykmeldingDTO[]
 ) => {
   return sykmeldinger.length === 0;
 };
 
-export const sykmeldtHarGyldigSykmelding = (sykmeldinger: Sykmelding[]) => {
+export const sykmeldtHarGyldigSykmelding = (sykmeldinger: SykmeldingDTO[]) => {
   const tomGrenseDato = new Date();
   return (
     sykmeldinger
@@ -53,8 +53,8 @@ export interface ArbeidsgivereForGyldigeSykmeldinger {
 }
 
 export const finnArbeidsgivereForGyldigeSykmeldinger = (
-  sykmeldinger: Sykmelding[],
-  naermesteLedere: NarmesteLeder[]
+  sykmeldinger: SykmeldingDTO[],
+  naermesteLedere: NarmesteLederDTO[]
 ): ArbeidsgivereForGyldigeSykmeldinger[] => {
   const dagensDato = new Date();
   return sykmeldinger


### PR DESCRIPTION
Add function factories for creating fixtures. 
Why? We want to migrate from builders to factories for easier use and maintenance.

Add Mock Service Worker for intercepting http-requests in tests and eventually add service worker for labs?

Use commit history for grouping of type of changes.