### PR TITLE
Move initiation of element modal to be mounted on to _app

### DIFF
--- a/src/components/arbeidsoppgaver/SlettArbeidsoppgaveButton.tsx
+++ b/src/components/arbeidsoppgaver/SlettArbeidsoppgaveButton.tsx
@@ -1,6 +1,6 @@
 import { Delete } from "@navikt/ds-icons";
 import { Button, Heading, Modal } from "@navikt/ds-react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { texts } from "../seplanen/texts";
 import { Row } from "../blocks/wrappers/Row";
@@ -27,13 +27,6 @@ export const SlettArbeidsoppgaveButton = ({
 }: Props) => {
   const [modalOpen, setModalOpen] = useState(false);
   const slettArbeidsoppgave = useSlettArbeidsoppgave();
-
-  useEffect(() => {
-    if (Modal.setAppElement) {
-      Modal.setAppElement("#__next");
-    }
-  }, []);
-
   if (!show) {
     return null;
   }

--- a/src/components/blocks/testscenarioselector/TestScenarioSelector.tsx
+++ b/src/components/blocks/testscenarioselector/TestScenarioSelector.tsx
@@ -60,12 +60,6 @@ export const TestScenarioSelector = () => {
   >();
 
   useEffect(() => {
-    if (Modal.setAppElement) {
-      Modal.setAppElement("#__next");
-    }
-  }, []);
-
-  useEffect(() => {
     if (activeTestScenario.isSuccess) {
       setSelectedScenario(activeTestScenario.data);
     }

--- a/src/components/landing/opprett/OpprettModalAG.tsx
+++ b/src/components/landing/opprett/OpprettModalAG.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import BaserTidligereSkjema from "../../../components/landing/opprett/BaserTidligereSkjema";
 import { useOpprettOppfolgingsplanAG } from "../../../api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG";
 import { Modal } from "@navikt/ds-react";
@@ -16,12 +16,6 @@ interface Props {
 
 const OpprettModalAG = ({ visOpprettModal, setVisOpprettModal }: Props) => {
   const opprettOppfolgingsplan = useOpprettOppfolgingsplanAG();
-
-  useEffect(() => {
-    if (Modal.setAppElement) {
-      Modal.setAppElement("#__next");
-    }
-  }, []);
 
   return (
     <Modal

--- a/src/components/landing/opprett/OpprettModalSM.tsx
+++ b/src/components/landing/opprett/OpprettModalSM.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ArbeidsgiverSkjemaForm from "./ArbeidsgiverSkjema";
 import BaserTidligereSkjema from "./BaserTidligereSkjema";
 import { Modal } from "@navikt/ds-react";
@@ -30,12 +30,6 @@ const OpprettModalSM = ({
 }: Props) => {
   const opprettOppfolgingsplan = useOpprettOppfolgingsplanSM();
   const kopierOppfolgingsplan = useKopierOppfolgingsplan();
-
-  useEffect(() => {
-    if (Modal.setAppElement) {
-      Modal.setAppElement("#__next");
-    }
-  }, []);
 
   const manglerNarmesteLeder =
     arbeidsgivere.length === 1 && !arbeidsgivere[0].harNaermesteLeder;

--- a/src/components/tiltak/SlettTiltakButton.tsx
+++ b/src/components/tiltak/SlettTiltakButton.tsx
@@ -1,6 +1,6 @@
 import { Button, Heading, Modal } from "@navikt/ds-react";
 import { Delete } from "@navikt/ds-icons";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { useSlettTiltakSM } from "../../api/queries/oppfolgingsplan/tiltakQueries";
 import { Row } from "../blocks/wrappers/Row";
@@ -20,12 +20,6 @@ interface Props {
 export const SlettTiltakButton = ({ tiltakId }: Props) => {
   const [modelOpen, setModalOpen] = useState(false);
   const slettTiltak = useSlettTiltakSM();
-
-  useEffect(() => {
-    if (Modal.setAppElement) {
-      Modal.setAppElement("#__next");
-    }
-  }, []);
 
   return (
     <>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { createGlobalStyle } from "styled-components";
 import { useAudience } from "../hooks/routeHooks";
 import { BreadcrumbsAppenderSM } from "../components/blocks/breadcrumbs/BreadcrumbsAppenderSM";
 import { BreadcrumbsAppenderAG } from "../components/blocks/breadcrumbs/BreadcrumbsAppenderAG";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   DehydratedState,
   Hydrate,
@@ -17,6 +17,7 @@ import { TestScenarioSelector } from "../components/blocks/testscenarioselector/
 import { displayTestScenarioSelector } from "../environments/publicEnv";
 import { configureLogger } from "@navikt/next-logger";
 import { OPErrorBoundary } from "../components/blocks/error/OPErrorBoundary";
+import { Modal } from "@navikt/ds-react";
 
 const minutesToMillis = (minutes: number) => {
   return 1000 * 60 * minutes;
@@ -58,6 +59,12 @@ function MyApp({
         },
       })
   );
+
+  useEffect(() => {
+    if (Modal.setAppElement) {
+      Modal.setAppElement("#__next");
+    }
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,0 @@
-import type { NextPage } from "next";
-
-const Home: NextPage = () => {
-  return <></>;
-};
-
-export default Home;


### PR DESCRIPTION
`#__next`-id'en lever kun når appen blir rendret som en next-app, og ikke på komponent-nivå.

Ved å slette `index.tsx` på root-nivå viser vi heller `404`-siden isteden for en tom side.