### PR TITLE
Close OP-approval-notification when accessing current/most recent OP

### DIFF
--- a/src/api/queries/varsel/ferdigstillingQueries.ts
+++ b/src/api/queries/varsel/ferdigstillingQueries.ts
@@ -1,0 +1,20 @@
+import { post } from "../../axios/axios";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { FerdigstillGodkjennVarsel } from "../../../types/varsel";
+
+export const useFerdigstillGodkjennPlanVarsel = () => {
+  const router = useRouter();
+  const basePath = router.basePath;
+
+  const ferdigstillVarsel = async (
+    ferdigstilling: FerdigstillGodkjennVarsel
+  ) => {
+    await post(`${basePath}/api/varsel/ferdigstill`, {
+      erSykmeldt: ferdigstilling.erSykmeldt,
+      oppfolgingsplanId: ferdigstilling.oppfolgingsplanId,
+    });
+  };
+
+  return useMutation(ferdigstillVarsel);
+};

--- a/src/pages/api/varsel/ferdigstill.ts
+++ b/src/pages/api/varsel/ferdigstill.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { beskyttetApi } from "../../../server/auth/beskyttetApi";
+import { getSyfoOppfolgingsplanserviceTokenFromRequest } from "../../../server/auth/tokenx/getTokenXFromRequest";
+import { ferdigstillVarsel } from "../../../server/service/oppfolgingsplanService";
+import { getFerdigstillingFromBody } from "../../../server/utils/requestUtils";
+import { isMockBackend } from "../../../server/utils/serverEnv";
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  if (isMockBackend) {
+    res.status(200).end();
+  } else {
+    const tokenX = await getSyfoOppfolgingsplanserviceTokenFromRequest(req);
+    const ferdigstilling = getFerdigstillingFromBody(req);
+    await ferdigstillVarsel(tokenX, ferdigstilling);
+    res.status(200).end();
+  }
+};
+
+export default beskyttetApi(handler);

--- a/src/pages/arbeidsgiver/[narmestelederid]/[oppfolgingsdialogId]/index.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/[oppfolgingsdialogId]/index.tsx
@@ -1,8 +1,9 @@
 import { NextPage } from "next";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { Oppfolgingsplan } from "../../../../types/oppfolgingsplan";
 import {
   getStatusPageTitleAndHeading,
+  planTilGodkjenningAG,
   StatusPageToDisplay,
   statusPageToDisplayAG,
 } from "../../../../utils/statusPageUtils";
@@ -18,6 +19,11 @@ import { GodkjennPlanAvslatt } from "../../../../components/status/godkjennplana
 import { ApprovalInformationAG } from "../../../../components/status/godkjentplan/ApprovalInformation";
 import { GodkjentPlanAvbrutt } from "../../../../components/status/godkjentplanavbrutt/GodkjentPlanAvbrutt";
 import { GodkjentPlan } from "../../../../components/status/godkjentplan/GodkjentPlan";
+import {
+  useOppfolgingsplanRouteId,
+  useNarmesteLederId,
+} from "../../../../hooks/routeHooks";
+import { useFerdigstillGodkjennPlanVarsel } from "../../../../api/queries/varsel/ferdigstillingQueries";
 
 interface ContentProps {
   oppfolgingsplan?: Oppfolgingsplan;
@@ -95,12 +101,37 @@ const Content = ({
 
 const OppfolgingsplanStatusAG: NextPage = () => {
   const aktivPlan = useAktivPlanAG();
+  const ferdigstillVarsel = useFerdigstillGodkjennPlanVarsel();
+  const oppfolgingsplanId = useOppfolgingsplanRouteId();
+  const narmestelederId = useNarmesteLederId();
   const pageToDisplay = statusPageToDisplayAG(aktivPlan);
   const { title, heading } = getStatusPageTitleAndHeading(
     pageToDisplay,
     aktivPlan?.virksomhet?.navn,
     aktivPlan?.arbeidstaker.navn || "Arbeidstakeren din"
   );
+
+  const erPlanTilGodkjenning = planTilGodkjenningAG(aktivPlan);
+
+  useEffect(() => {
+    if (oppfolgingsplanId && narmestelederId) {
+      const varselKey = `ferdigstiltVarselAG-${narmestelederId}`;
+      const ferdigstiltVarsel = sessionStorage.getItem(varselKey);
+      if (ferdigstiltVarsel || !erPlanTilGodkjenning) {
+        return;
+      }
+      ferdigstillVarsel.mutate({
+        erSykmeldt: false,
+        oppfolgingsplanId: oppfolgingsplanId,
+      });
+      sessionStorage.setItem(varselKey, "true");
+    }
+  }, [
+    erPlanTilGodkjenning,
+    ferdigstillVarsel,
+    oppfolgingsplanId,
+    narmestelederId,
+  ]);
 
   return (
     <ArbeidsgiverSide title={title} heading={heading}>

--- a/src/pages/sykmeldt/[oppfolgingsdialogId]/index.tsx
+++ b/src/pages/sykmeldt/[oppfolgingsdialogId]/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from "next";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { GodkjentPlanAvbrutt } from "../../../components/status/godkjentplanavbrutt/GodkjentPlanAvbrutt";
 import { GodkjennPlanAvslattOgGodkjent } from "../../../components/status/godkjennplanavslattoggodkjent/GodkjennPlanAvslattOgGodkjent";
 import { GodkjennPlanAvslatt } from "../../../components/status/godkjennplanavslatt/GodkjennPlanAvslatt";
@@ -17,7 +17,10 @@ import {
   getStatusPageTitleAndHeading,
   StatusPageToDisplay,
   statusPageToDisplaySM,
+  planTilGodkjenningSM,
 } from "../../../utils/statusPageUtils";
+import { useOppfolgingsplanRouteId } from "../../../hooks/routeHooks";
+import { useFerdigstillGodkjennPlanVarsel } from "../../../api/queries/varsel/ferdigstillingQueries";
 
 interface ContentProps {
   oppfolgingsplan?: Oppfolgingsplan;
@@ -98,6 +101,8 @@ const Content = ({
 
 const OppfolgingsplanStatus: NextPage = () => {
   const aktivPlan = useAktivPlanSM();
+  const ferdigstillVarsel = useFerdigstillGodkjennPlanVarsel();
+  const oppfolgingsplanId = useOppfolgingsplanRouteId();
 
   const pageToDisplay = statusPageToDisplaySM(aktivPlan);
   const { title, heading } = getStatusPageTitleAndHeading(
@@ -105,6 +110,23 @@ const OppfolgingsplanStatus: NextPage = () => {
     aktivPlan?.virksomhet?.navn,
     "Lederen din"
   );
+
+  const erPlanTilGodkjenning = planTilGodkjenningSM(aktivPlan);
+
+  useEffect(() => {
+    if (oppfolgingsplanId) {
+      const varselKey = `ferdigstiltVarselSM-${oppfolgingsplanId}`;
+      const ferdigstiltVarsel = sessionStorage.getItem(varselKey);
+      if (ferdigstiltVarsel || !erPlanTilGodkjenning) {
+        return;
+      }
+      ferdigstillVarsel.mutate({
+        erSykmeldt: true,
+        oppfolgingsplanId: oppfolgingsplanId,
+      });
+      sessionStorage.setItem(varselKey, "true");
+    }
+  }, [erPlanTilGodkjenning, ferdigstillVarsel, oppfolgingsplanId]);
 
   return (
     <SykmeldtSide title={title} heading={heading}>

--- a/src/server/service/oppfolgingsplanService.ts
+++ b/src/server/service/oppfolgingsplanService.ts
@@ -24,6 +24,7 @@ import {
   Kommentar,
   Tiltak,
 } from "../../types/oppfolgingsplan";
+import { FerdigstillGodkjennVarsel } from "../../types/varsel";
 
 export async function getNarmesteLeder(
   accessToken: string,
@@ -445,6 +446,22 @@ export async function getPdf(accessToken: string, oppfolgingsplanId: string) {
     {
       accessToken: accessToken,
       responseType: "arraybuffer",
+    }
+  );
+}
+
+export async function ferdigstillVarsel(
+  accessToken: string,
+  ferdigstilling: FerdigstillGodkjennVarsel
+) {
+  return await post(
+    `${serverEnv.SYFOOPPFOLGINGSPLANSERVICE_HOST}/syfooppfolgingsplanservice/api/v2/varsel/ferdigstill`,
+    {
+      erSykmeldt: ferdigstilling.erSykmeldt,
+      oppfolgingsplanId: ferdigstilling.oppfolgingsplanId,
+    },
+    {
+      accessToken: accessToken,
     }
   );
 }

--- a/src/server/utils/errors.ts
+++ b/src/server/utils/errors.ts
@@ -21,3 +21,11 @@ export const handleQueryParamError = (
     generalError(`Malformed query params: ${JSON.stringify(params)}`)
   );
 };
+
+export const handleRequestBodyError = (
+  ...params: (unknown | unknown[] | undefined)[]
+): never => {
+  throw new ApiErrorException(
+    generalError(`Invalid types in request body: ${JSON.stringify(params)}`)
+  );
+};

--- a/src/server/utils/requestUtils.ts
+++ b/src/server/utils/requestUtils.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest } from "next";
-import { handleQueryParamError } from "./errors";
+import { handleQueryParamError, handleRequestBodyError } from "./errors";
 import { NAV_PERSONIDENT_HEADER } from "../../api/axios/axios";
 
 export const getSykmeldtFnrFromRequest = (req: NextApiRequest) => {
@@ -72,4 +72,18 @@ export const getKommentarIdFromRequest = (req: NextApiRequest): string => {
   }
 
   return kommentarId;
+};
+
+export const getFerdigstillingFromBody = (req: NextApiRequest) => {
+  const ferdigstilling = req.body;
+  const { erSykmeldt, oppfolgingsplanId } = ferdigstilling;
+
+  if (
+    typeof erSykmeldt !== "boolean" ||
+    typeof oppfolgingsplanId !== "number"
+  ) {
+    return handleRequestBodyError(erSykmeldt, oppfolgingsplanId);
+  }
+
+  return ferdigstilling;
 };

--- a/src/types/varsel.ts
+++ b/src/types/varsel.ts
@@ -1,0 +1,4 @@
+export type FerdigstillGodkjennVarsel = {
+  erSykmeldt: boolean;
+  oppfolgingsplanId: number;
+};

--- a/src/utils/statusPageUtils.ts
+++ b/src/utils/statusPageUtils.ts
@@ -52,6 +52,18 @@ export const getStatusPageTitleAndHeading = (
   }
 };
 
+export const planTilGodkjenningSM = (
+  oppfolgingsplan: Oppfolgingsplan | undefined
+) => {
+  return oppfolgingsplan && erPlanTilGodkjenningSM(oppfolgingsplan);
+};
+
+export const planTilGodkjenningAG = (
+  oppfolgingsplan: Oppfolgingsplan | undefined
+) => {
+  return oppfolgingsplan && erPlanTilGodkjenningAG(oppfolgingsplan);
+};
+
 const harMottattGodkjenningerFraArbeidsgiver = (
   oppfolgingsplan: Oppfolgingsplan
 ): boolean => {


### PR DESCRIPTION
When an OP is sent for approval, a notification (bedskjed) is sent to the other party (approving side, AG/SM). This notification should be closed on accessing the OP review page automatically. To do this, a POST request, containing context(AG/SM) and OP-id, is sent when an active OP is accessed once every session to syfooppfolgingsplanservice, which in turn utilizes varselbus kafka topic to close the relevant notification.