### PR TITLE
Add registries to dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    registries: '*'
     groups:
       aksel-dependencies:
         patterns:


### PR DESCRIPTION
Fikk en feilmelding inne på Dependabot-oppsett om at registries ikke ble brukt til noe, prøver å fikse det