### PR TITLE
Allow to run build on workflow dispatch

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,5 +1,7 @@
 name: Build & Deploy
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   next-app:


### PR DESCRIPTION
Når dependabot-PRer er merget så må github actions starte bygging på nytt. Dette skjer ikke automatisk fordi merge er gjort av en bot.