### PR TITLE
Log data if 409-error

### DIFF
--- a/src/components/status/GodkjennOppfolgingsplan.tsx
+++ b/src/components/status/GodkjennOppfolgingsplan.tsx
@@ -2,24 +2,22 @@ import { Alert, BodyLong, Button, Checkbox, Heading } from "@navikt/ds-react";
 import { useState } from "react";
 import { SpacedDiv } from "../blocks/wrappers/SpacedDiv";
 import { useGodkjennsistOppfolgingsplan } from "../../api/queries/oppfolgingsplan/oppfolgingsplanQueries";
-import { GodkjenningDTO } from "../../schema/oppfolgingsplanSchema";
+import { OppfolgingsplanDTO } from "../../schema/oppfolgingsplanSchema";
 
 export type MotpartNavnForAltinn = "arbeidstakeren" | "arbeidsgiveren din";
 
 interface Props {
-  oppfolgingsplanId: number;
+  oppfolgingsplan: OppfolgingsplanDTO;
   motpartNavnForAltinn: MotpartNavnForAltinn;
-  godkjenninger: GodkjenningDTO[];
 }
 
 export const GodkjennOppfolgingsplan = ({
-  oppfolgingsplanId,
+  oppfolgingsplan,
   motpartNavnForAltinn,
-  godkjenninger,
 }: Props) => {
   const [delMedNav, setDelMedNav] = useState(false);
   const godkjennOppfolgingsplan =
-    useGodkjennsistOppfolgingsplan(oppfolgingsplanId);
+    useGodkjennsistOppfolgingsplan(oppfolgingsplan);
 
   return (
     <SpacedDiv>
@@ -31,7 +29,9 @@ export const GodkjennOppfolgingsplan = ({
         automatisk bli tilgjengelige for arbeidsplassen i Altinn.
       </BodyLong>
       <SpacedDiv>
-        {godkjenninger.find((godkjenning) => godkjenning.delMedNav) ? (
+        {oppfolgingsplan.godkjenninger.find(
+          (godkjenning) => godkjenning.delMedNav,
+        ) ? (
           <Alert variant="info">
             Planen vil bli delt med NAV når du godkjenner den.
           </Alert>

--- a/src/components/status/godkjennmottatt/GodkjennPlanMottatt.tsx
+++ b/src/components/status/godkjennmottatt/GodkjennPlanMottatt.tsx
@@ -53,9 +53,8 @@ export const GodkjennPlanMottatt = ({
       />
 
       <GodkjennOppfolgingsplan
-        oppfolgingsplanId={oppfolgingsplan.id}
+        oppfolgingsplan={oppfolgingsplan}
         motpartNavnForAltinn={motpartNavnForAltinn}
-        godkjenninger={oppfolgingsplan.godkjenninger}
       />
 
       <TilLandingssideKnapp />

--- a/src/components/status/godkjennplanavslattoggodkjent/GodkjennPlanAvslattOgGodkjent.tsx
+++ b/src/components/status/godkjennplanavslattoggodkjent/GodkjennPlanAvslattOgGodkjent.tsx
@@ -54,9 +54,8 @@ export const GodkjennPlanAvslattOgGodkjent = ({
       </Row>
 
       <GodkjennOppfolgingsplan
-        oppfolgingsplanId={oppfolgingsplan.id}
+        oppfolgingsplan={oppfolgingsplan}
         motpartNavnForAltinn={motpartNavnForAltinn}
-        godkjenninger={oppfolgingsplan.godkjenninger}
       />
       <TilLandingssideKnapp />
     </SpacedDiv>


### PR DESCRIPTION
- Returnerer nå faktiske feilkoder til frontend i stedet for kun 500
- Dersom godkjennSist får 409, så logger vi litt info og reloader siden slik at riktig state lastes inn

Da kan vi grave litt dersom det skjer, og dersom det skjer så blir det uansett riktig state igjen fordi siden lastes inn på ny.