### PR TITLE
Stop using session storage

### DIFF
--- a/src/api/queries/varsel/ferdigstillingQueries.ts
+++ b/src/api/queries/varsel/ferdigstillingQueries.ts
@@ -1,16 +1,36 @@
 import { post } from "../../axios/axios";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
-export const useFerdigstillGodkjennPlanVarsel = () => {
+const queryKeyHasFerdigStiltVarselForPlanId = (oppfolgingsplanId: number) => [
+  "hasFerdigstiltVarselForPlanId",
+  oppfolgingsplanId,
+];
+
+export const useFerdigstillVarselForPlanMutation = (
+  oppfolgingsplanId: number,
+) => {
   const router = useRouter();
   const basePath = router.basePath;
 
-  const ferdigstillVarsel = async (oppfolgingsplanId: number) => {
-    await post(
-      `${basePath}/api/varsel/${oppfolgingsplanId}/ferdigstill`,
-      "useFerdigstillGodkjennPlanVarsel",
-    );
+  const queryClient = useQueryClient();
+
+  const { data: hasFerdigstiltVarselForPlan } = useQuery({
+    queryKey: queryKeyHasFerdigStiltVarselForPlanId(oppfolgingsplanId),
+    initialData: false,
+  });
+
+  const ferdigstillVarsel = async () => {
+    if (!hasFerdigstiltVarselForPlan) {
+      await post(
+        `${basePath}/api/varsel/${oppfolgingsplanId}/ferdigstill`,
+        "useFerdigstillGodkjennPlanVarsel",
+      );
+      queryClient.setQueryData(
+        queryKeyHasFerdigStiltVarselForPlanId(oppfolgingsplanId),
+        true,
+      );
+    }
   };
 
   return useMutation({ mutationFn: ferdigstillVarsel });

--- a/src/components/status/godkjennmottatt/GodkjennPlanMottatt.tsx
+++ b/src/components/status/godkjennmottatt/GodkjennPlanMottatt.tsx
@@ -10,9 +10,7 @@ import { TilLandingssideKnapp } from "../TilLandingssideKnapp";
 import { SpacedDiv } from "../../blocks/wrappers/SpacedDiv";
 import { BodyLong } from "@navikt/ds-react";
 import { Row } from "../../blocks/wrappers/Row";
-import { useFerdigstillGodkjennPlanVarsel } from "../../../api/queries/varsel/ferdigstillingQueries";
-import { useOppfolgingsplanRouteId } from "../../../hooks/routeHooks";
-import { useFerdigstillVarsel } from "../utils/varselHooks";
+import { useFerdigstillVarselForPlan } from "../utils/varselHooks";
 import { OppfolgingsplanDTO } from "../../../schema/oppfolgingsplanSchema";
 
 interface Props {
@@ -28,10 +26,8 @@ export const GodkjennPlanMottatt = ({
 }: Props) => {
   const gyldighetstidspunkt =
     oppfolgingsplan?.godkjenninger?.[0]?.gyldighetstidspunkt;
-  const ferdigstillVarsel = useFerdigstillGodkjennPlanVarsel();
-  const oppfolgingsplanId = useOppfolgingsplanRouteId();
 
-  useFerdigstillVarsel(ferdigstillVarsel, oppfolgingsplanId);
+  useFerdigstillVarselForPlan();
 
   if (!gyldighetstidspunkt) {
     return null;

--- a/src/components/status/godkjennplanavslattoggodkjent/GodkjennPlanAvslattOgGodkjent.tsx
+++ b/src/components/status/godkjennplanavslattoggodkjent/GodkjennPlanAvslattOgGodkjent.tsx
@@ -9,9 +9,7 @@ import {
 import { GodkjennPlanTidspunkter } from "../GodkjennPlanTidspunkter";
 import { SePlan } from "../SePlan";
 import { TilLandingssideKnapp } from "../TilLandingssideKnapp";
-import { useFerdigstillVarsel } from "../utils/varselHooks";
-import { useFerdigstillGodkjennPlanVarsel } from "../../../api/queries/varsel/ferdigstillingQueries";
-import { useOppfolgingsplanRouteId } from "../../../hooks/routeHooks";
+import { useFerdigstillVarselForPlan } from "../utils/varselHooks";
 import {
   GodkjenningDTO,
   OppfolgingsplanDTO,
@@ -33,10 +31,8 @@ export const GodkjennPlanAvslattOgGodkjent = ({
       return godkjenning.godkjent;
     },
   )?.gyldighetstidspunkt;
-  const ferdigstillVarsel = useFerdigstillGodkjennPlanVarsel();
-  const oppfolgingsplanId = useOppfolgingsplanRouteId();
 
-  useFerdigstillVarsel(ferdigstillVarsel, oppfolgingsplanId);
+  useFerdigstillVarselForPlan();
 
   if (!gyldighetstidspunkt) {
     return null;

--- a/src/components/status/utils/useShowSMIsReservertInfoForAG.ts
+++ b/src/components/status/utils/useShowSMIsReservertInfoForAG.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useKontaktinfo } from "../../../api/queries/kontaktinfo/kontaktinfoQueries";
+import { useNarmesteLederId } from "../../../hooks/routeHooks";
+
+function queryKeyHasDismissedSMIsReservertInfoForNLID(narmesteLederId: string) {
+  return ["AGHasDismissedSMIsReservertInfoForNLID", narmesteLederId];
+}
+
+function useShowSMIsReservertInfoForAG() {
+  const queryClient = useQueryClient();
+
+  const narmesteLederId = useNarmesteLederId()!;
+  const sykmeldtesKontaktinfo = useKontaktinfo();
+
+  const [showSMIsReservertInfo, setShowSMIsReservertInfo] = useState(false);
+
+  const { data: hasDismissedSMIsReservertInfo } = useQuery({
+    queryKey: queryKeyHasDismissedSMIsReservertInfoForNLID(narmesteLederId),
+    initialData: false,
+  });
+
+  useEffect(() => {
+    if (
+      sykmeldtesKontaktinfo.isSuccess &&
+      !sykmeldtesKontaktinfo.data.skalHaVarsel &&
+      !hasDismissedSMIsReservertInfo
+    ) {
+      setShowSMIsReservertInfo(true);
+    }
+  }, [
+    sykmeldtesKontaktinfo.isSuccess,
+    sykmeldtesKontaktinfo.data?.skalHaVarsel,
+    hasDismissedSMIsReservertInfo,
+  ]);
+
+  const dismissSMIsReservertInfo = () => {
+    queryClient.setQueryData(
+      queryKeyHasDismissedSMIsReservertInfoForNLID(narmesteLederId),
+      () => true,
+    );
+    setShowSMIsReservertInfo(false);
+  };
+
+  return {
+    showSMIsReservertInfo,
+    dismissSMIsReservertInfo,
+  };
+}
+
+export default useShowSMIsReservertInfoForAG;

--- a/src/components/status/utils/varselHooks.ts
+++ b/src/components/status/utils/varselHooks.ts
@@ -1,19 +1,15 @@
-import { UseMutationResult } from "@tanstack/react-query";
 import { useEffect } from "react";
 
-export const useFerdigstillVarsel = (
-  ferdigstillVarsel: UseMutationResult<void, unknown, number, unknown>,
-  oppfolgingsplanId: number,
-) => {
+import { useFerdigstillVarselForPlanMutation } from "../../../api/queries/varsel/ferdigstillingQueries";
+import { useOppfolgingsplanRouteId } from "../../../hooks/routeHooks";
+
+export const useFerdigstillVarselForPlan = () => {
+  const oppfolgingsplanId = useOppfolgingsplanRouteId();
+
+  const { mutate: mutateFerdigstillVarsel } =
+    useFerdigstillVarselForPlanMutation(oppfolgingsplanId);
+
   useEffect(() => {
-    if (oppfolgingsplanId) {
-      const varselKey = `ferdigstilt-varsel-${oppfolgingsplanId}`;
-      const alleredeFerdigstilt = sessionStorage.getItem(varselKey);
-      if (alleredeFerdigstilt) {
-        return;
-      }
-      ferdigstillVarsel.mutate(oppfolgingsplanId);
-      sessionStorage.setItem(varselKey, "true");
-    }
-  }, [ferdigstillVarsel, oppfolgingsplanId]);
+    mutateFerdigstillVarsel();
+  }, [mutateFerdigstillVarsel]);
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,15 +1,17 @@
+import React, { useEffect, useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
 import "@navikt/dinesykmeldte-sidemeny/dist/style.css";
+import { configureLogger } from "@navikt/next-logger";
+
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import { useAudience } from "../hooks/routeHooks";
 import { BreadcrumbsAppenderSM } from "../components/blocks/breadcrumbs/BreadcrumbsAppenderSM";
 import { BreadcrumbsAppenderAG } from "../components/blocks/breadcrumbs/BreadcrumbsAppenderAG";
-import React, { useEffect } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { TestScenarioSelector } from "../components/blocks/testscenarioselector/TestScenarioSelector";
 import { displayTestScenarioSelector } from "../environments/publicEnv";
-import { configureLogger } from "@navikt/next-logger";
 import { OPErrorBoundary } from "../components/blocks/error/OPErrorBoundary";
 import { initFaro } from "../faro/initFaro";
 import { minutesToMillis } from "../utils/dateUtils";
@@ -27,15 +29,19 @@ const TestScenarioDevTools = () => {
 
 function MyApp({ Component, pageProps }: AppProps) {
   const { isAudienceSykmeldt } = useAudience();
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        gcTime: minutesToMillis(60),
-        staleTime: minutesToMillis(30),
-      },
-    },
-  });
+
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            gcTime: minutesToMillis(60),
+            staleTime: minutesToMillis(30),
+          },
+        },
+      }),
+  );
 
   useEffect(() => {
     initFaro();

--- a/src/pages/arbeidsgiver/[narmestelederid]/index.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/index.tsx
@@ -1,5 +1,6 @@
 import { NextPage } from "next";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
+
 import {
   useAktiveOppfolgingsplanerAG,
   useOppfolgingsplanerAG,
@@ -7,8 +8,6 @@ import {
 } from "../../../api/queries/arbeidsgiver/oppfolgingsplanerQueriesAG";
 import { beskyttetSideUtenProps } from "../../../auth/beskyttetSide";
 import { SamtaleStotte } from "../../../components/blocks/samtalestotte/SamtaleStotte";
-import { useKontaktinfo } from "../../../api/queries/kontaktinfo/kontaktinfoQueries";
-import { useNarmesteLederId } from "../../../hooks/routeHooks";
 import OpprettModalAG from "../../../components/landing/opprett/OpprettModalAG";
 import ArbeidsgiverSide from "../../../components/blocks/wrappers/ArbeidsgiverSide";
 import IngenPlanerCardAG from "../../../components/landing/opprett/IngenPlanerCardAG";
@@ -19,6 +18,7 @@ import { IkkeTilgangTilAnsattInfoBoks } from "../../../components/blocks/infobok
 import { useTilgangAG } from "../../../api/queries/arbeidsgiver/tilgangQueriesAG";
 import OppfolgingsdialogTeasereAG from "../../../components/landing/teaser/arbeidsgiver/OppfolgingsdialogTeasereAG";
 import ReservertSykmeldtMelding from "../../../components/landing/ReservertSykmeldtMeldingAG";
+import useShowSMIsReservertInfoForAG from "../../../components/status/utils/useShowSMIsReservertInfoForAG";
 
 const PageContent = () => {
   const allePlaner = useOppfolgingsplanerAG();
@@ -66,41 +66,17 @@ const PageContent = () => {
 };
 
 const Home: NextPage = () => {
-  const narmesteLederId = useNarmesteLederId();
-  const sykmeldtesKontaktinfo = useKontaktinfo();
-  const [visReservertInfoboks, setVisReservertInfoboks] = useState(false);
-
-  useEffect(() => {
-    const hasSeenReservertInfo = sessionStorage?.getItem(
-      `${narmesteLederId}-seen-varsel`,
-    );
-    if (
-      sykmeldtesKontaktinfo.isSuccess &&
-      !sykmeldtesKontaktinfo.data.skalHaVarsel &&
-      !hasSeenReservertInfo
-    ) {
-      setVisReservertInfoboks(true);
-    }
-  }, [
-    narmesteLederId,
-    sykmeldtesKontaktinfo.data?.skalHaVarsel,
-    sykmeldtesKontaktinfo.isSuccess,
-  ]);
-
-  const setHasReadReservertInfoBoks = () => {
-    sessionStorage?.setItem(`${narmesteLederId}-seen-varsel`, "true");
-    setVisReservertInfoboks(false);
-  };
+  const { showSMIsReservertInfo, dismissSMIsReservertInfo } =
+    useShowSMIsReservertInfoForAG();
 
   return (
     <ArbeidsgiverSide
       title="Oppfølgingsplaner - Oversikt"
       heading="Oppfølgingsplaner"
     >
-      {visReservertInfoboks && (
-        <ReservertSykmeldtMelding onClose={setHasReadReservertInfoBoks} />
-      )}
-      {!visReservertInfoboks && (
+      {showSMIsReservertInfo ? (
+        <ReservertSykmeldtMelding onClose={dismissSMIsReservertInfo} />
+      ) : (
         <>
           <OppfolgingsdialogerInfoPersonvern
             ingress="Oppfølgingsplanen skal gjøre det lettere å bli i jobben. Hensikten er å finne ut hvilke oppgaver som kan gjøres hvis det blir lagt til rette for det.


### PR DESCRIPTION
Use query client local storage instead.

Retain query client cache on route changes.
Replace using session storage with using query client for
- avoid multiple ferdigstill varsel calls.
- to remember if reservert-info has been dismissed.

