### PR TITLE
chore: change docker image to node:20-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12 AS runtime
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:20-slim AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #1739

## Changes

Replace `gcr.io/distroless/nodejs20-debian12` with `europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:20-slim` to resolve the `libssl3` vulnerability (`pkg:deb/debian/libssl3@3.0.18-1~deb12u2`) present in the Debian 12 distroless image.

The new image aligns with the pattern already used in other NAV frontend repos (e.g. `syfo-oppfolgingsplan-frontend`).